### PR TITLE
Removed the widths from the styles

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -91,14 +91,6 @@ main {
 
   > div {
     margin-bottom: $space-lg;
-
-    @include md {
-      width: 90%;
-    }
-
-    @include xl {
-      width: 80%;
-    }
   }
 }
 

--- a/assets/scss/_forms.scss
+++ b/assets/scss/_forms.scss
@@ -1,6 +1,5 @@
 form {
   margin-top: $space-xl;
-  max-width: 300px;
   width: 100%;
 
   .d--ib {
@@ -12,7 +11,6 @@ form {
   }
 
   @include sm {
-    max-width: 450px;
 
     .d--ib {
       display: inline-block;
@@ -35,7 +33,6 @@ form {
   }
 
   @include md {
-    max-width: 800px;
   }
 }
 
@@ -43,7 +40,6 @@ form.form--lg {
 
   @include sm {
     width: 110%;
-    max-width: 800px;
   }
 
   fieldset legend,


### PR DESCRIPTION
Removes the widths from the _base.scss and the _forms.scss so the page aligns closer to the figma designs. 

Question is this the best way to do this?

Are we still concerned about merging from upstream? 

Closes #7 