### PR TITLE
Set min-height to max-height in the header

### DIFF
--- a/assets/scss/components/_header.scss
+++ b/assets/scss/components/_header.scss
@@ -55,7 +55,7 @@ header {
 
   .canada-flag {
     height: auto;
-    min-height: 40px;
+    max-height: 40px;
     width: 272px;
     margin-bottom: $space-sm;
 


### PR DESCRIPTION
Super tiny CSS change, bringing in a fix I made for IE11 that was never ported over to the starter app.

Details are in these two PRs
- https://github.com/cds-snc/cra-claim-tax-benefits/pull/401
- https://github.com/cds-snc/cra-claim-tax-benefits/pull/415

