### PR TITLE
Allow inline styles through CSP

### DIFF
--- a/config/csp.config.js
+++ b/config/csp.config.js
@@ -20,6 +20,6 @@ module.exports = {
   baseUri: ["'none'"],
   fontSrc: ["'self'", 'https://fonts.gstatic.com'],
   imgSrc: ["'self'", 'data:'],
-  styleSrc: ["'self'", 'https://fonts.googleapis.com'],
+  styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
   upgradeInsecureRequests,
 }


### PR DESCRIPTION
This fixes a weird problem you can see in Edge with rendering svgs. 

On (gov-approved) versions of Edge, The Canadian flag SVG is black and white instead of red.

It turns out that this problem is caused by the CSP disabling inline styles.

The SVG uses inline styles to colour the flag component. By allowing inline styles through, we can solve our bug in Edge.

Original PR is here: https://github.com/cds-snc/cra-claim-tax-benefits/pull/417

