### PR TITLE
fix radio id generation

### DIFF
--- a/views/macros/radios.njk
+++ b/views/macros/radios.njk
@@ -21,8 +21,8 @@
                 {% endif %}
                 {% for index, val in values %}
                     <div class="multiple-choice__item">
-                        <input id="{{ key }}{{ val }}" name="{{ key }}" type="radio" value="{{ val }}" {% if value == val %} checked="checked" {% endif %} {% if errors and errors[key] %} aria-describedby="{{ key + '-error' }}" aria-invalid="true" {% endif %}>
-                        <label for="{{ key }}{{ val }}">{{ __(val) }}</label>
+                        <input id="{{ key }}{{ index }}" name="{{ key }}" type="radio" value="{{ val }}" {% if value == val %} checked="checked" {% endif %} {% if errors and errors[key] %} aria-describedby="{{ key + '-error' }}" aria-invalid="true" {% endif %}>
+                        <label for="{{ key }}{{ index }}">{{ __(val) }}</label>
                     </div>
                 {% endfor %}
             </div>


### PR DESCRIPTION
it was generating id by key + val, but val contained our string of text
swapped val for index, to generate IDs in a pattern of radio_name1, radio_name2, etc

Before:
![image](https://user-images.githubusercontent.com/6607541/77804299-930f3580-7055-11ea-910d-146142f46749.png)

After:
![image](https://user-images.githubusercontent.com/6607541/77804396-c8b41e80-7055-11ea-80d4-364bb4ed5fde.png)

