### PR TITLE
Add a GITHUB_SHA meta tag to HTML <head>

### DIFF
--- a/views/base.njk
+++ b/views/base.njk
@@ -15,6 +15,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta name="description" content="[ALPHA] Node Starter App">
         <meta name="csrf-token" content="{{ csrfToken }}">
+        {% if GITHUB_SHA %}<meta name="keywords" content="{{ GITHUB_SHA }}">{% endif %}
         <link rel="shortcut icon" href="/favicon.png" type="image/x-icon" sizes="32x32">
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
         <link href="https://fonts.googleapis.com/css?family=Lato:700|Noto+Sans:400,700&amp;display=fallback" rel="stylesheet">


### PR DESCRIPTION
If there's an env var named GITHUB_SHA available on the server while the app is running, then create a meta tag in the <head> with the value.

When a Docker container is created using our CI, this variable should be baked in.