### PR TITLE
Split development/production webpack builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5017,7 +5017,8 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -8034,6 +8035,7 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
       "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+      "dev": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^1.1.0",
@@ -8046,6 +8048,7 @@
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -10121,7 +10124,8 @@
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -12295,10 +12299,19 @@
         }
       }
     },
+    "webpack-merge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "webpack-notifier": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/webpack-notifier/-/webpack-notifier-1.8.0.tgz",
       "integrity": "sha512-I6t76NoPe5DZCCm5geELmDV2wlJ89LbU425uN6T2FG8Ywrrt1ZcUMz6g8yWGNg4pttqTPFQJYUPjWAlzUEQ+cQ==",
+      "dev": true,
       "requires": {
         "node-notifier": "^5.1.2",
         "object-assign": "^4.1.0",
@@ -12308,12 +12321,14 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "node": ">=10"
   },
   "scripts": {
-    "build": "webpack --mode=production",
+    "build": "webpack --config webpack.prod.js",
     "dev": "cross-env nodemon --exec npm run dev:dist",
-    "dev:dist": "webpack --mode=development && cross-env NODE_ENV=development  node ./bin/www",
+    "dev:dist": "webpack --config webpack.dev.js && cross-env NODE_ENV=development  node ./bin/www",
     "start": "npm run build && cross-env NODE_ENV=production node ./bin/www",
     "lint": "node node_modules/eslint/bin/eslint.js config utils routes bin/www app.js",
     "prettier": "prettier --write '**/*.{ts,js,css,html}'",
@@ -53,7 +53,7 @@
     "tailwindcss": "^1.1.3",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11",
-    "webpack-notifier": "^1.8.0"
+    "webpack-merge": "^4.2.2"
   },
   "devDependencies": {
     "@aws-cdk/aws-docdb": "1.17.1",
@@ -79,7 +79,8 @@
     "prettier": "^1.19.1",
     "rimraf": "^3.0.2",
     "supertest": "^4.0.2",
-    "supertest-session": "^4.0.0"
+    "supertest-session": "^4.0.0",
+    "webpack-notifier": "^1.8.0"
   },
   "nodemonConfig": {
     "ext": "js,json,njk,scss",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,0 +1,53 @@
+const path = require('path')
+const webpack = require('webpack')
+const { CleanWebpackPlugin } = require('clean-webpack-plugin')
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+
+module.exports = {
+  entry: {
+    styles: './assets/scss/app.scss',
+  },
+  output: {
+    filename: 'js/[name].[chunkhash].js',
+    path: path.resolve(__dirname, 'public/dist'),
+  },
+  stats: 'errors-only',
+  performance: {
+    maxAssetSize: 100000, // set max asset size to 100 kb
+  },
+  plugins: [
+    new webpack.ProgressPlugin(),
+    new CleanWebpackPlugin(),
+    new MiniCssExtractPlugin({
+      filename: 'css/styles.css',
+    }),
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.scss$/,
+        use: [MiniCssExtractPlugin.loader, 'css-loader', 'postcss-loader'],
+      },
+      {
+        test: /\.(js|jsx)$/,
+        include: [path.resolve(__dirname, 'src')],
+        loader: 'babel-loader',
+        options: {
+          plugins: ['syntax-dynamic-import'],
+          presets: [
+            [
+              '@babel/preset-env',
+              {
+                modules: false,
+              },
+            ],
+          ],
+        },
+      },
+      {
+        test: /\.css$/i,
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+}

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,15 @@
+const merge = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+const WebpackNotifierPlugin = require('webpack-notifier')
+
+module.exports = merge(common, {
+  mode: 'development',
+  plugins: [
+    new WebpackNotifierPlugin({
+      title: 'Node Starter Build',
+      contentImage:
+        'https://github.com/cds-snc/common-assets/raw/master/EN/cds-snc.png',
+    }),
+  ],
+});

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,20 @@
+const merge = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'production',
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendors: {
+          priority: -10,
+          test: /[\\/]node_modules[\\/]/,
+        },
+      },
+      chunks: 'async',
+      minChunks: 1,
+      minSize: 30000,
+      name: true,
+    },
+  },
+});


### PR DESCRIPTION
Splits the webpack config to separate production and development. Main difference at the moment is turning off the notifier on production builds, and setting some production-specific optimizations ... probably more we can do here.