### PR TITLE
Add `github-sha` as the meta name along with the commit hash

### DIFF
--- a/views/base.njk
+++ b/views/base.njk
@@ -15,7 +15,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta name="description" content="[{{ __('app.phase') }}] {{ __('app.title') }}">
         <meta name="csrf-token" content="{{ csrfToken }}">
-        {% if GITHUB_SHA %}<meta name="keywords" content="{{ GITHUB_SHA }}">{% endif %}
+        {% if GITHUB_SHA %}<meta name="github-sha" content="{{ GITHUB_SHA }}">{% endif %}
         <link rel="shortcut icon" href="/favicon.png" type="image/x-icon" sizes="32x32">
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
         <link href="https://fonts.googleapis.com/css?family=Lato:700|Noto+Sans:400,700&amp;display=fallback" rel="stylesheet">


### PR DESCRIPTION
Right now it just puts the hash in, but doesn't say what it is.

This will make it more like the CSRF token that is also in the header.