### PR TITLE
Keep the language link at the top

### DIFF
--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -27,15 +27,15 @@
     }
 */
 
-/* ≥ 336px */
+/* ≥ 332px */
 @mixin xs {
-  @media screen and (min-width: 21em) {
+  @media screen and (min-width: 23em) {
     @content;
   }
 }
-/* ≥ 568px */
+/* ≥ 526px */
 @mixin sm {
-  @media screen and (min-width: 35.5em) {
+  @media screen and (min-width: 36.5em) {
     @content;
   }
 }

--- a/assets/scss/components/_header.scss
+++ b/assets/scss/components/_header.scss
@@ -11,18 +11,15 @@ header {
   }
 
   .fip-container {
-    flex-direction: column;
+    flex-direction: row;
+    justify-content: space-between;
     display: flex;
-
-    @include sm {
-      justify-content: space-between;
-      flex-direction: row;
-    }
   }
 
   .language-link {
     text-align: left;
     margin-bottom: $space-sm;
+    font-size: .85em;
 
     h2 {
       @include visuallyHidden();
@@ -48,8 +45,13 @@ header {
       }
     }
 
+    @include xs {
+      font-size: .9em;
+    }
+
     @include sm {
       margin-bottom: 0;
+      font-size: 1em;
     }
   }
 
@@ -58,6 +60,7 @@ header {
     max-height: 40px;
     width: 272px;
     margin-bottom: $space-sm;
+    margin-right: $space-sm;
 
     @include sm {
       width: 360px;


### PR DESCRIPTION
The flag gets really small but we've all seen it before. Gives us a bit more screen real-estate.

It looks like using `em`s for the media queries has led to them shifting a bit on this new project, but it really only matters for the smaller sizes (updated the comments for the `xs` and `sm` media queries).

## Screenshots

| before | after |
|--------|-------|
|  "Francais" link under the FIP logo   |  "Francais" link beside the FIP logo   |
|  <img width="673" alt="Screen Shot 2020-04-02 at 11 15 14 AM" src="https://user-images.githubusercontent.com/2454380/78266220-79497480-74d3-11ea-85e5-56d3a4faaee0.png">   |  <img width="673" alt="Screen Shot 2020-04-02 at 11 15 18 AM" src="https://user-images.githubusercontent.com/2454380/78266208-764e8400-74d3-11ea-8016-4f5178f9b48a.png">  |



