### PR TITLE
some mobile touches

### DIFF
--- a/assets/scss/_forms.scss
+++ b/assets/scss/_forms.scss
@@ -1,6 +1,5 @@
 form {
   margin-top: $space-md;
-  max-width: 300px;
   width: 100%;
 
   .d--ib {
@@ -12,7 +11,7 @@ form {
   }
 
   @include sm {
-    max-width: 450px;
+    max-width: 500px;
 
     .d--ib {
       display: inline-block;

--- a/views/macros/radios.njk
+++ b/views/macros/radios.njk
@@ -2,7 +2,7 @@
     <div class="{{ 'has-error' if errors and errors[key] }}">
         <fieldset class="fieldset">
             <legend class="fieldset__legend">
-            <h1>
+            <h1 class="text-3xl md:text-4xl">
                 {% if attributes.required %}
                     <span aria-hidden="true" class="required">*</span>
                 {% endif %}


### PR DESCRIPTION
Get rid of max-width on our forms at smallest size
we may consider adding something back in when we have text inputs
bump up the max-width size on medium screens
add some tailwind classes to our header to have smaller font-size on mobile

![image](https://user-images.githubusercontent.com/6607541/78291351-3e573900-74f3-11ea-8a4c-e9cd9b9c94d2.png)
