### PR TITLE
Fixing order on some income to match figma

### DIFF
--- a/routes/question-your-situation-some-income/question-your-situation-some-income.njk
+++ b/routes/question-your-situation-some-income/question-your-situation-some-income.njk
@@ -10,8 +10,8 @@
             {{ radioButtons('some_income',
                 [
                     { value: '1', text:__('your_situation.some_income.1')},
-                    { value: '2', text:__('your_situation.some_income.2')},
-                    { value: '3', text:__('your_situation.some_income.3')}
+                    { value: '3', text:__('your_situation.some_income.3')},
+                    { value: '2', text:__('your_situation.some_income.2')}
                 ],
                 data.your_situation.some_income,
                 __('form.your_situation.some_income'),


### PR DESCRIPTION
Item 2 and 3 were out of order now aligns with figma: 
![image](https://user-images.githubusercontent.com/87738/78315924-5c8d5b00-752c-11ea-9b52-07b913afffd6.png)
