### PR TITLE
Clean up the way benefits are displayed 

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -42,6 +42,14 @@ ul {
   }
 }
 
+p + ul {
+  margin-top: -$space-xs;
+
+  @include xs {
+    margin-top: -$space-sm;
+  }
+}
+
 ol,
 ul {
   padding-left: $space-md;

--- a/routes/results/results.njk
+++ b/routes/results/results.njk
@@ -13,7 +13,7 @@
         {% endfor %}
     </ul>
     {% endif %}
-    <div>
+    <div class="mt-10">
         {% for benefit in benefits %}
             {% include "benefits/" + benefit + ".njk" %}
         {% endfor %}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,12 +2,18 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        blue: {
+          '200': '#E1F0F8',
+        },
         gray: {
           '400': '#cbcbcb',
           '600': '#808080',
           '700': '#666666',
         },
       },
+    },
+    boxShadow: {
+      result: '0px 0px 12px -2px rgba(0,0,0,0.4)',
     },
   },
   variants: {},

--- a/views/macros/benefit-result.njk
+++ b/views/macros/benefit-result.njk
@@ -1,13 +1,12 @@
 {% macro benefitResult(id, header, preamble, button, boxes) %}
-<div class="m-5 p-5 shadow-lg">
-    <h2 class="text-xl font-bold mb-5" id="{{ id }}">{{ header }}</h2>
-
+<div class="m-5 p-5 shadow-result">
+    <h2 class="text-2xl font-bold mb-6" id="{{ id }}">{{ header }}</h2>
     {% for box in boxes %}
-        <div class="bg-blue-200 p-5 m-1 text-blue-900 text-center text-lg">
-            <p><strong>{{ box }}</strong></p>
+        <div class="bg-blue-200 p-5 m-1 text-blue-900 text-center">
+            <p class="m-0"><strong>{{ box }}</strong></p>
         </div>
     {% endfor %}
-    <div class="pb-5 pt-1"> 
+    <div class="pb-5 mt-6">
         {{ preamble | safe}}
     </div>
     <a href="{{ button.link }}" class="full-width font-semibold button-link py-6 px-5 border shadow"> {{ button.text }}</a>


### PR DESCRIPTION
A bunch of changes here to the benefits list on the last page.

- boosted the box shadow so that the benefits are visually separated
- made the text bigger for the titles of the benefits
- removed spacing under paragraphs when followed by a list
- changed the blue background to one that matches figma

Generally they look a lot better.


| before | after |
|--------|-------|
|  <img width="1364" alt="Screen Shot 2020-04-03 at 8 48 29 AM" src="https://user-images.githubusercontent.com/2454380/78362378-fc2c0700-7587-11ea-8c6e-3ae526edd848.png">  | <img width="1364" alt="Screen Shot 2020-04-03 at 8 48 32 AM" src="https://user-images.githubusercontent.com/2454380/78362362-f7ffe980-7587-11ea-9202-908546205206.png">  |


