### PR TITLE
Redirect /en and /fr to respective start pages

### DIFF
--- a/routes/start/start.controller.js
+++ b/routes/start/start.controller.js
@@ -5,6 +5,8 @@ module.exports = (app, route) => {
 
   // redirect from "/" → "/start"
   app.get('/', (req, res) => res.redirect(route.path[req.locale]))
+  app.get('/en', (req, res) => res.redirect(route.path.en))
+  app.get('/fr', (req, res) => res.redirect(route.path.fr))
 
   route.draw(app).get(async (req, res) => {
     req.session = null;


### PR DESCRIPTION
When users arrive at `/` we had been redirecting to `/en/start`, but arriving at `/en` or `/fr` would result in errors.

This change will handle those `/en` and `/fr` routes, redirecting to the language-appropriate start pages.