### PR TITLE
Improved skip-link markup and styling

### DIFF
--- a/assets/scss/components/_skip-link.scss
+++ b/assets/scss/components/_skip-link.scss
@@ -1,38 +1,25 @@
-.skip-link {
-    position:absolute !important;
-    width:1px !important;
-    height:1px !important;
-    margin:0 !important;
-    overflow:hidden !important;
-    clip:rect(0 0 0 0) !important;
-    -webkit-clip-path:inset(50%) !important;
-    clip-path:inset(50%) !important;
-    white-space:nowrap !important;
-    -webkit-font-smoothing:antialiased;
-    -moz-osx-font-smoothing:grayscale;
-    font-size:14px;
-    font-size:.875rem;
-    line-height:1.14286;
-    display:block;
-    padding:10px 15px
-}
-.skip-link:active,.skip-link:focus{
-    position:static !important;
-    width:auto !important;
-    height:auto !important;
-    margin:inherit !important;
-    overflow:visible !important;
-    clip:auto !important;
-    -webkit-clip-path:none !important;
-    clip-path:none !important;
-    white-space:inherit !important
-}
+#skip-link-container {
+  width: 100%;
+  position: absolute;
+  z-index: 5;
+  text-align: center;
+  top: 10px;
 
-.skip-link:link,.skip-link:visited,.skip-link:hover,.skip-link:active,.skip-link:focus {
-    color:#0b0c0c
-}
-
-.skip-link:focus{
-    outline:3px solid $color-yellow;
-    background-color:$color-yellow;
+  #skip-link {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    white-space: nowrap;
+    
+    &:focus {
+      position: static;
+      padding: 5px;
+      width: auto;
+      height: auto;
+      overflow: auto;
+      background-color: white;
+      text-align: center;
+    }
+  }
 }

--- a/views/base.njk
+++ b/views/base.njk
@@ -24,7 +24,10 @@
         <title>{{ __('app.title') }}</title>
     </head>
     <body>
-        <a class="skip-link" href="#content">{{ __('Skip to main content') }}</a>
+        <nav>
+            <div id="skip-link-container"><a href="#content" id="skip-link">{{ __('Skip to main content') }}</a></div>
+        </nav>
+
         <div class="outer-container">
             <header>
                 {% include "_includes/phaseBanner.njk" %}


### PR DESCRIPTION
(stole it from CRA)

Adds a landmark region (`<nav>`) around the Skip to main content link. Also changes up the styling a bit.