### PR TITLE
Don't run tests on every push

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "npm run lint && npm test"
+      "pre-commit": "npm run lint"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Changed the Husky config so that it runs pre-commit linting checks, but not pre-push tests.