### PR TITLE
Remove h1 from radios legend

### DIFF
--- a/views/macros/radios.njk
+++ b/views/macros/radios.njk
@@ -2,7 +2,7 @@
     <div class="{{ 'has-error' if errors and errors[key] }}">
         <fieldset class="fieldset">
             <legend class="fieldset__legend">
-            <h1 class="text-3xl md:text-4xl">{% if attributes.required %}<span aria-hidden="true" class="required">*</span>{% endif %} {{ question }} {% if attributes.required %} <span class="required">{{ __("required")}}</span>{% endif %}</h1>
+                {% if attributes.required %}<span aria-hidden="true" class="required">*</span>{% endif %} {{ question }} {% if attributes.required %} <span class="required">{{ __("required")}}</span>{% endif %}
             </legend>
             {% if attributes.hint %}
                 <span class="form-message">


### PR DESCRIPTION
In anticipation of coming design changes. 

In our a11y review, we discussed changing up the heading order so that the question is not the `<h1>` element. This removes the `<h1>` element from the radios macro.