### PR TITLE
Whitelist dynamic classnames for purgecss

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,10 +1,13 @@
 const cssnano = require('cssnano')
 const purgecss = require('@fullhuman/postcss-purgecss')({
   // Specify the paths to all of the template files in your project
-  content: ['./routes/**/*.njk', './views/*.njk', './views/macros/*.njk', './views/_includes/*.njk', './views/benefits/*.njk'],
+  content: ['./routes/**/*.njk', './views/**/*.njk'],
 
   // Include any special characters you're using in this regular expression
   defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || [],
+
+  // whitelist dynamic class names
+  whitelist: ['banner--blue','banner--blue__icon'],
 })
 
 module.exports = {


### PR DESCRIPTION
Purgecss was not detecting the dynamically named classes in the banner macro, so things weren't displaying right on the production builds. Added a whitelist entry for the dynamic class names. 

![image](https://user-images.githubusercontent.com/1187115/78678536-13843080-78b7-11ea-9856-376ac1329750.png)
