### PR TITLE
Add 'alpha.canada.ca' as the cookie domain

### DIFF
--- a/config/cookieSession.config.js
+++ b/config/cookieSession.config.js
@@ -7,13 +7,15 @@
   more docs here: https://expressjs.com/en/resources/middleware/cookie-session.html
 */
 const oneHour = 1000 * 60 * 60
-const sessionName = `ctb-${process.env.COOKIE_SECRET ||
-  Math.floor(new Date().getTime() / oneHour)}`
+const sessionName = `ctb-${
+  process.env.COOKIE_SECRET || Math.floor(new Date().getTime() / oneHour)
+}`
 
 const cookieSessionConfig = {
   name: sessionName,
   secret: sessionName,
   cookie: {
+    domain: 'alpha.canada.ca',
     httpOnly: true,
     maxAge: oneHour,
     sameSite: true,


### PR DESCRIPTION
This means that cookies will be shared across _all_ alpha.canada.ca domains.

Shouldn't be a real problem, as there isn't any personal information being stored in the session.