### PR TITLE
Add a leading dot to the cookie domain

### DIFF
--- a/config/cookieSession.config.js
+++ b/config/cookieSession.config.js
@@ -15,7 +15,7 @@ const cookieSessionConfig = {
   name: sessionName,
   secret: sessionName,
   cookie: {
-    domain: 'alpha.canada.ca',
+    domain: '.alpha.canada.ca',
     httpOnly: true,
     maxAge: oneHour,
     sameSite: true,


### PR DESCRIPTION
The spec says that you don't need a leading dot, but a few stackoverflow answers I was reading say that you do.

Let's see if this allows us to share the session between the english and the french subdomains.