### PR TITLE
Add truthy check to the getId function for the back button

### DIFF
--- a/views/_includes/script.njk
+++ b/views/_includes/script.njk
@@ -11,14 +11,14 @@
     }
 
     document.addEventListener('DOMContentLoaded', function () {
-        document.getElementById('backButton').addEventListener('click', function() {
+        document.getElementById('backButton') && document.getElementById('backButton').addEventListener('click', function() {
             window.history.go(-1);
         }, true)
     }, false);
 
 </script>
 <script>
-    if (typeof Promise !== "function" && document.querySelector('details') !== null) 
+    if (typeof Promise !== "function" && document.querySelector('details') !== null)
         document.write('<script src="/js/details-element-polyfill.js"><\/script>');
 </script>
 


### PR DESCRIPTION
If it can't find a button on the page, it won't set the click event listener.

Closes #159.