### PR TITLE
Set .alpha.canada.ca domain for cookies if on Azure

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,11 +37,10 @@ if (process.env.NODE_ENV !== 'test') {
   // CSRF setup
   app.use(
     csrf({
-      cookie: {
-        sameSite: true,
-        secure: true,
-      },
+      cookie: true,
       signed: true,
+      sameSite: true,
+      secure: true,
     }),
   )
 
@@ -52,8 +51,7 @@ if (process.env.NODE_ENV !== 'test') {
   })
 }
 
-// in production: use redis for sessions
-// but this works for now
+// cookie sessions are character limited, but this works for now
 app.use(cookieSession(cookieSessionConfig))
 
 // public assets go here (css, js, etc)

--- a/config/cookieSession.config.js
+++ b/config/cookieSession.config.js
@@ -14,12 +14,14 @@ const sessionName = `ctb-${
 const cookieSessionConfig = {
   name: sessionName,
   secret: sessionName,
-  cookie: {
-    domain: '.alpha.canada.ca',
-    httpOnly: true,
-    maxAge: oneHour,
-    sameSite: true,
-  },
+  httpOnly: true,
+  maxAge: oneHour,
+  sameSite: true,
+}
+
+// if running on Azure, set the cookie domain to .alpha.canada.ca
+if (process.env.APP_SERVICE) {
+  cookieSessionConfig.domain = '.alpha.canada.ca'
 }
 
 module.exports = cookieSessionConfig


### PR DESCRIPTION
Since our prod service will have 2 URLs pointing at it, we want to be able to share cookies between the domains so that your session will be preserved.

Explicitly set the '.alpha.canada.ca' domain in the cookie config so that user's info can be shared from the french to the english domain and vice-versa.

ALSO

The way we were setting our cookie config variables were wrong as well (haha oops), so this PR updates them to the correct syntax.

Sources:
- https://github.com/expressjs/csurf#csurfoptions
- https://github.com/expressjs/cookie-session#options