### PR TITLE
Add other potential help section

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -132,5 +132,7 @@
   "start.intro.3": "This tool only suggests federal programs at this time. New benefits are still being created, and we are working to include them as soon as possible. You may want to check back again.",
   "start.details.summary": "Are you a Canadian stuck abroad?",
   "start.details.p.1": "If you’re a Canadian abroad and need help to pay for your trip home, you can get <a href='https://travel.gc.ca/assistance/emergency-info/financial-assistance/covid-19-financial-help' target='_blank'>an emergency loan</a>.",
-  "lost_job.title": "Lost income due to COVID-19"
+  "lost_job.title": "Lost income due to COVID-19",
+  "results.other_potential_help": "Other potential help",
+  "results.other_potential_help.preamble": "The following help is available as well:"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -108,8 +108,6 @@
   "start.subtitle": "Trouvez quelle aide financière vous est offerte",
   "start.title": "Argent pour la COVID-19",
   "start_over": "Recommencer",
-  "student_debt.1": false,
-  "student_debt.2": false,
   "student_loan.box1": "Les paiements sont automatiquement supsendus",
   "student_loan.box2": "Du 30 mars 2020 jusqu’au 30 septembre 2020",
   "student_loan.header": "Arrêt des paiements de votre dette d’étude pendant 6 mois",
@@ -135,5 +133,7 @@
   "start.intro.3": "Ce service ne fait que suggérer des programmes fédéraux pour l’instant. De nouvelles prestations sont constamment créées et nous travaillons à les inclure aussitôt que possible. Revenez consulter cet outil afin de voir quelles nouvelles prestations s’appliquent à vous.",
   "start.details.summary": "Êtes vous un Canadien actuellement à l’étranger?",
   "start.details.p.1": "Si vous êtes un Canadien actuellement à l’étranger et que vous avez besoin d’aide financière pour revenir au Canada, vous pouvez demander <a href='https://voyage.gc.ca/assistance/info-d-urgence/assistance-financiere/covid-19-aide-financiere' target='_blank'>un prêt d’urgence</a>.",
-  "lost_job.title": "Perte de revenu en lien avec la COVID-19"
+  "lost_job.title": "Perte de revenu en lien avec la COVID-19",
+  "results.other_potential_help": "Aide supplémentaire disponible",
+  "results.other_potential_help.preamble": "L’aide suivante est également disponible :"
 }

--- a/routes/results/results.njk
+++ b/routes/results/results.njk
@@ -25,6 +25,15 @@
         {% endfor %}
     </div>
 
-    <p class="bg-red-200 p-4 hidden">(debug): {{ benefits }}</p>
+    <h2 class="text-3xl">{{ __('results.other_potential_help') }}</h2>
+
+    <p>{{ __('results.other_potential_help.preamble') }}</p>
+
+    <ul class="list-disc list-inside mt-4">
+        <li><a href="#gst_credit"> {{ __("gst_credit.header")}}</a></li>
+    </ul>
+    <div class="mt-10">
+        {% include "benefits/gst_credit.njk" %}
+    </div>
 
 {% endblock %}


### PR DESCRIPTION
Closes #139 

Adds "Other potential help" section on Results screen.

This section currently just displays GST credit info, and is displayed all the time.