### PR TITLE
[WIP] Add acr env vars back (and add new one)

### DIFF
--- a/terraform/azure/app-service-docker.tf
+++ b/terraform/azure/app-service-docker.tf
@@ -24,6 +24,14 @@ resource "azurerm_app_service" "app_service" {
     always_on        = true
   }
 
+  app_settings = {
+    "APP_SERVICE"                     = "true"
+    "DOCKER_ENABLE_CI"                = "true"
+    "DOCKER_REGISTRY_SERVER_URL"      = "https://${azurerm_container_registry.container_registry.login_server}"
+    "DOCKER_REGISTRY_SERVER_USERNAME" = azurerm_container_registry.container_registry.admin_username
+    "DOCKER_REGISTRY_SERVER_PASSWORD" = azurerm_container_registry.container_registry.admin_password
+  }
+
   logs {
     http_logs {
       file_system {


### PR DESCRIPTION
Pushing this PR up for visibility. Don't merge, will be pushing additional changes.

I misunderstood how that github action functions. The app service still needs the acr credentials to pull the image. So had to add this back in for now.

Will modify tomorrow to bring up a keyvault.