### PR TITLE
No cerb no results

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -98,6 +98,8 @@
     "one": "%s way to get help",
     "other": "%s ways to get help"
   },
+  "results_title_no_cerb": "Check back again in a week or two",
+  "results.no_cerb.preamble": "At this time, people who have lost some income but not all their income are not covered by the Canada Emergency Response Benefit (CERB). New measures are still being announced, and we’re working to update this tool as quickly as possible. Check back in a week or two.",
   "rrif.1": "Yes",
   "rrif.2": "No",
   "rrif.header": "Lower mandatory withdrawals for your Registered Retirement Income Fund (RRIF)",

--- a/locales/en.json
+++ b/locales/en.json
@@ -100,6 +100,8 @@
   },
   "results_title_no_cerb": "Check back again in a week or two",
   "results.no_cerb.preamble": "At this time, people who have lost some income but not all their income are not covered by the Canada Emergency Response Benefit (CERB). New measures are still being announced, and we’re working to update this tool as quickly as possible. Check back in a week or two.",
+  "results_title_no_results": "Check back in a few weeks",
+  "results.no_results.preamble": "Your situation does not match any of the benefits included here at the moment. We’re working to add more programs, so you may want to check back in a few weeks or if your situation changes.",
   "rrif.1": "Yes",
   "rrif.2": "No",
   "rrif.header": "Lower mandatory withdrawals for your Registered Retirement Income Fund (RRIF)",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -96,6 +96,8 @@
     "one": "%s programme d’aide pour vous",
     "other": "%s programmes d’aide pour vous"
   },
+  "results_title_no_cerb": "Revenez voir dans une semaine ou deux",
+  "results.no_cerb.preamble": "Pour l’instant, les gens qui ont perdu une portion de leur revenu, et non l’entièreté de leur revenu ne sont pas couverts par la Prestation canadienne d’urgence (PCU). De nouvelles prestations sont constamment créées et nous travaillons à les inclure aussitôt que possible. Revenez consulter cet outil dans une semaine ou deux.",
   "rrif.1": "rrif.1",
   "rrif.2": "rrif.2",
   "rrif.header": "Diminution du montant de retrait obligatoire de votre fond enregistré de revenu de retraite",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -98,6 +98,8 @@
   },
   "results_title_no_cerb": "Revenez voir dans une semaine ou deux",
   "results.no_cerb.preamble": "Pour l’instant, les gens qui ont perdu une portion de leur revenu, et non l’entièreté de leur revenu ne sont pas couverts par la Prestation canadienne d’urgence (PCU). De nouvelles prestations sont constamment créées et nous travaillons à les inclure aussitôt que possible. Revenez consulter cet outil dans une semaine ou deux.",
+  "results_title_no_results": "Revenez voir dans quelques semaines",
+  "results.no_results.preamble": "Aucune prestation actuelle ne s’applique à votre situation. Nous ajoutons les prestations au fur et à mesure qu’elles sont annoncées et nous travaillons à les inclure aussitôt que possible. Revenez consulter cet outil plus tard, ou si votre situation change.",
   "rrif.1": "rrif.1",
   "rrif.2": "rrif.2",
   "rrif.header": "Diminution du montant de retrait obligatoire de votre fond enregistré de revenu de retraite",

--- a/routes/results/results.controller.js
+++ b/routes/results/results.controller.js
@@ -12,6 +12,8 @@ module.exports = (app, route) => {
 
       res.render(name, routeUtils.getViewData(req, {
         benefits: benefits,
+        no_results: benefits.length === 0,
+        // no_cerb: true,
       }))
     })
     .post(route.applySchema(Schema), route.doRedirect())

--- a/routes/results/results.njk
+++ b/routes/results/results.njk
@@ -3,7 +3,12 @@
 
 {% block content %}
 
-    <h1>{{ __n("results_title", benefits.length) }}</h1>
+    {% if no_cerb %}
+        <h1>{{ __("results_title_no_cerb") }}</h1>
+        <p>{{ __("results.no_cerb.preamble") }}</p>
+    {% else %}
+        <h1>{{ __n("results_title", benefits.length) }}</h1>
+    {% endif %}
 
     {% if not data.lost_job %}
         <div>{{ banner('red', '<p>' + __('results.banner') + '</p>') }}</div>

--- a/routes/results/results.njk
+++ b/routes/results/results.njk
@@ -6,7 +6,7 @@
     {% if no_cerb %}
         <h1>{{ __("results_title_no_cerb") }}</h1>
         <p>{{ __("results.no_cerb.preamble") }}</p>
-    {% else if no_results %}
+    {% elif no_results %}
         <h1>{{ __("results_title_no_results") }}</h1>
         <p>{{ __("results.no_results.preamble") }}</p>
     {% else %}

--- a/routes/results/results.njk
+++ b/routes/results/results.njk
@@ -6,6 +6,9 @@
     {% if no_cerb %}
         <h1>{{ __("results_title_no_cerb") }}</h1>
         <p>{{ __("results.no_cerb.preamble") }}</p>
+    {% else if no_results %}
+        <h1>{{ __("results_title_no_results") }}</h1>
+        <p>{{ __("results.no_results.preamble") }}</p>
     {% else %}
         <h1>{{ __n("results_title", benefits.length) }}</h1>
     {% endif %}


### PR DESCRIPTION
Closes #141 

Adds "No CERB" and "No Results" states for the Results screen.

This PR contains the content update and placeholder flag for no_cerb. no_results is true if there are no entries on the benefits array. The no_cerb calculation will come in a separate PR.

![image](https://user-images.githubusercontent.com/1187115/78846454-d4023500-79d9-11ea-905d-b01993c34e6e.png)

To test no_results, just navigate to results without answering any questions and you should see no_results. There is also a path through (no income loss, working from home, no to everything else) that should also render the no_results screen.

To see the no_cerb state, for now just uncomment the flag in the controller.