### PR TITLE
Add banner--red whitelist to postCSS config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -4,10 +4,10 @@ const purgecss = require('@fullhuman/postcss-purgecss')({
   content: ['./routes/**/*.njk', './views/**/*.njk'],
 
   // Include any special characters you're using in this regular expression
-  defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || [],
+  defaultExtractor: (content) => content.match(/[\w-/:]+(?<!:)/g) || [],
 
   // whitelist dynamic class names
-  whitelist: ['banner--blue','banner--blue__icon'],
+  whitelist: ['banner--blue', 'banner--blue__icon', 'banner--red'],
 })
 
 module.exports = {


### PR DESCRIPTION
Just like the blue banner CSS, we want the red banner CSS not to be stripped out by postCSS.