### PR TITLE
Add middleware to switch domains on production

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,7 +12,7 @@ const morganConfig = require('./config/morgan.config')
 const path = require('path')
 const cookieSession = require('cookie-session')
 const cookieSessionConfig = require('./config/cookieSession.config')
-const { hasData } = require('./utils')
+const { hasData, getDomain } = require('./utils')
 const { addNunjucksFilters } = require('./filters')
 const csp = require('./config/csp.config')
 const csrf = require('csurf')
@@ -80,11 +80,30 @@ app.locals.hasData = hasData
 app.locals.basedir = path.join(__dirname, './views')
 app.set('views', [path.join(__dirname, './views')])
 
+// middleware to set a unique user id per session
 app.use(function (req, res, next) {
   // set a unique user id per session
   if (!req.session.id) req.session.id = uuidv4()
   // add user session req.locals so that the logger has access to it
   req.locals = { session: req.session }
+
+  next()
+})
+
+// middleware to redirect french paths to the french domain and english paths to the english domain
+app.use(function (req, res, next) {
+  // if not running on production azure, skip this
+  if (!process.env.APP_SERVICE) return next()
+
+  const domain = getDomain(req)
+
+  // if `/fr/` appears in the path for the english domain, redirect to DOMAIN_FR
+  if (req.path.startsWith('/fr/') && domain.includes(process.env.DOMAIN_EN))
+    return res.redirect(`https://${process.env.DOMAIN_FR}${req.path}`)
+
+  // if `/en/` appears in the path for the french domain, redirect to DOMAIN_EN
+  if (req.path.startsWith('/en/') && domain.includes(process.env.DOMAIN_FR))
+    return res.redirect(`https://${process.env.DOMAIN_EN}${req.path}`)
 
   next()
 })

--- a/app.js
+++ b/app.js
@@ -91,6 +91,7 @@ app.use(function (req, res, next) {
 })
 
 // middleware to redirect french paths to the french domain and english paths to the english domain
+/* istanbul ignore next */
 app.use(function (req, res, next) {
   // if not running on production azure, skip this
   if (!process.env.APP_SERVICE) return next()


### PR DESCRIPTION
## Add middleware to switch domains on production

Basically the logic is:

if there is an 'fr' in the path and we're on the english domain, switch to the french domain.

if there is an 'en' in the path and we're on the french domain, switch to the english one.

Since the cookies share info now, the user shouldn't notice.

This is pretty impossible to test on heroku or wherever else, so you're going to have to take my word for it that I tested it myself.

This is the end of a trilogy:

1. #126: added our domains in a public `.env` file, and defaulted the french root domain to "/debut"
2. #165: adjusted our cookie settings so that cookies are shared between sessions
3. this one: changes the domain when the language changes, knowing that our session is preserved

Finally closes #97 

## gif

![domains](https://user-images.githubusercontent.com/2454380/78850630-a91dde00-79e5-11ea-8263-3606cff0d75d.gif)
