### PR TITLE
Set production mode in Dockerfile for builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="-"
 
 ARG GITHUB_SHA_ARG
 ENV GITHUB_SHA=$GITHUB_SHA_ARG
+ENV NODE_ENV=production
 
 COPY . /src
 


### PR DESCRIPTION
...not sure why node_env in npm start isn't working in our docker builds. But this fixes it.

Before:
styles.css: 913k

After:
styles.css: 17.2k