### PR TITLE
Add start over to results

### DIFF
--- a/routes/results/results.controller.js
+++ b/routes/results/results.controller.js
@@ -14,6 +14,7 @@ module.exports = (app, route) => {
         benefits: benefits,
         no_results: benefits.length === 0,
         no_cerb: getNoCerb(data),
+        hideBackButton: true,
       }))
     })
     .post(route.applySchema(Schema), route.doRedirect())

--- a/routes/results/results.njk
+++ b/routes/results/results.njk
@@ -3,6 +3,13 @@
 
 {% block content %}
 
+    <div class="flex flex-row">
+        {% include "_includes/back-link.njk" %}
+        <div class="inline -mt-12">
+            <a class="ml-6 py-3 button-link transparent" href="/clear"><img src="/img/times-circle.svg" aria-hidden="true" /><span>{{ __('start_over') }}</span></a>
+        </div>
+    </div>
+
     {% if no_cerb %}
         <h1>{{ __("results_title_no_cerb") }}</h1>
         <p>{{ __("results.no_cerb.preamble") }}</p>


### PR DESCRIPTION
Closes #193 

![image](https://user-images.githubusercontent.com/1187115/78935726-4d059900-7a7b-11ea-8d78-d052e646a5b8.png)

As far as implementation, I wanted to re-use the existing back-link include, but I didn't want to mess it up with some kind of display logic depending on route. So I hid the one in the base template, then included it directly in results inside a flex-row with the new button.