### PR TITLE
Fix/back button markup

### DIFF
--- a/assets/scss/components/_buttons.scss
+++ b/assets/scss/components/_buttons.scss
@@ -89,9 +89,14 @@ a.button-link {
 }
 
 .back-button-container {
+  &.no-js {
+    display: none;
+  }
+
   margin-bottom: $space-lg;
   //this so that if the button doesn't display, it doesn't affect the necessary margin for the header
   margin-top: -$space-lg;
+
 
   @include sm {
     margin-bottom: $space-xl;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "aws": "cd cdk && cdk synth && node deploy",
     "aws-bootstrap": "node cdk/bootstrap.js",
     "aws-destroy": "node cdk/destroy.js",
-    "comb": "jsoncomb --normalise \"./locales/*.json\""
+    "comb": "jsoncomb --normalise \"./locales/*.json\"",
+    "cypress:open": "node ./node_modules/.bin/cypress open"
   },
   "husky": {
     "hooks": {

--- a/routes/results/results.njk
+++ b/routes/results/results.njk
@@ -6,7 +6,7 @@
     <div class="flex flex-row">
         {% include "_includes/back-link.njk" %}
         <div class="inline -mt-12">
-            <a class="ml-6 py-3 button-link transparent" href="/clear"><img src="/img/times-circle.svg" aria-hidden="true" /><span>{{ __('start_over') }}</span></a>
+            <a class="ml-6 py-3 button-link transparent" href="/clear"><img src="/img/times-circle.svg" alt="" /><span>{{ __('start_over') }}</span></a>
         </div>
     </div>
 

--- a/views/_includes/back-link.njk
+++ b/views/_includes/back-link.njk
@@ -1,5 +1,5 @@
 <div class="back-button-container no-js">
-  <button aria-label="{{__('button.back')}}" id="backButton" class="back-button">
+  <button aria-label="{{__('button.back')}}" id="backButton" class="back-button" role=”link”>
     <img src="/img/arrow-circle-left.svg" aria-hidden="true" /><span>{{__('button.back')}}</span>
   </button>
 </div>

--- a/views/_includes/back-link.njk
+++ b/views/_includes/back-link.njk
@@ -1,5 +1,5 @@
 <div class="back-button-container no-js">
-  <button aria-label="{{__('button.back')}}" id="backButton" class="back-button" role=”link”>
+  <button aria-label="{{__('button.back')}}" id="backButton" class="back-button" role="link">
     <img src="/img/arrow-circle-left.svg" aria-hidden="true" /><span>{{__('button.back')}}</span>
   </button>
 </div>

--- a/views/_includes/back-link.njk
+++ b/views/_includes/back-link.njk
@@ -1,5 +1,5 @@
 <div class="back-button-container no-js">
   <button aria-label="{{__('button.back')}}" id="backButton" class="back-button" role="link">
-    <img src="/img/arrow-circle-left.svg" aria-hidden="true" /><span>{{__('button.back')}}</span>
+    <img src="/img/arrow-circle-left.svg" alt="" /><span>{{__('button.back')}}</span>
   </button>
 </div>

--- a/views/_includes/back-link.njk
+++ b/views/_includes/back-link.njk
@@ -1,9 +1,3 @@
-<noscript>
-  {# we could put this in the header, but it has more context here #}
-  <style type="text/css">
-    .back-button-container {display:none;}
-  </style>
-</noscript>
 <div class="back-button-container">
   <button aria-label="{{__('button.back')}}" id="backButton" class="back-button">
     <img src="/img/arrow-circle-left.svg" aria-hidden="true" /><span>{{__('button.back')}}</span>

--- a/views/_includes/back-link.njk
+++ b/views/_includes/back-link.njk
@@ -1,4 +1,4 @@
-<div class="back-button-container">
+<div class="back-button-container no-js">
   <button aria-label="{{__('button.back')}}" id="backButton" class="back-button">
     <img src="/img/arrow-circle-left.svg" aria-hidden="true" /><span>{{__('button.back')}}</span>
   </button>

--- a/views/_includes/script.njk
+++ b/views/_includes/script.njk
@@ -12,7 +12,9 @@
 
     var backLinkContainer = document.getElementsByClassName('back-button-container')[0];
     
-    backLinkContainer.className = backLinkContainer.className.replace(/\bno-js\b/g, "");
+    if (backLinkContainer) {
+        backLinkContainer.className = backLinkContainer.className.replace(/\bno-js\b/g, "");
+    }
 
     document.addEventListener('DOMContentLoaded', function () {
         document.getElementById('backButton') && document.getElementById('backButton').addEventListener('click', function() {

--- a/views/_includes/script.njk
+++ b/views/_includes/script.njk
@@ -10,6 +10,10 @@
         })
     }
 
+    var backLinkContainer = document.getElementsByClassName('back-button-container')[0];
+    
+    backLinkContainer.className = backLinkContainer.className.replace(/\bno-js\b/g, "");
+
     document.addEventListener('DOMContentLoaded', function () {
         document.getElementById('backButton') && document.getElementById('backButton').addEventListener('click', function() {
             window.history.go(-1);

--- a/views/base.njk
+++ b/views/base.njk
@@ -21,6 +21,12 @@
         <link href="https://fonts.googleapis.com/css?family=Lato:700|Noto+Sans:400,700&amp;display=fallback" rel="stylesheet">
         <link rel="stylesheet" href="/dist/css/styles.css">
         <title>{{ __('app.title') }}</title>
+        <noscript>
+            {# hides the back button if js is not on. noscript tags are allowed in the header in html5 #}
+            <style type="text/css">
+                .back-button-container {display:none;}
+            </style>
+        </noscript>
     </head>
     <body>
         <nav>

--- a/views/base.njk
+++ b/views/base.njk
@@ -21,12 +21,6 @@
         <link href="https://fonts.googleapis.com/css?family=Lato:700|Noto+Sans:400,700&amp;display=fallback" rel="stylesheet">
         <link rel="stylesheet" href="/dist/css/styles.css">
         <title>{{ __('app.title') }}</title>
-        <noscript>
-            {# hides the back button if js is not on. noscript tags are allowed in the header in html5 #}
-            <style type="text/css">
-                .back-button-container {display:none;}
-            </style>
-        </noscript>
     </head>
     <body>
         <nav>

--- a/views/macros/buttons.njk
+++ b/views/macros/buttons.njk
@@ -3,7 +3,7 @@
         <div class="buttons--left next-button">
             <button class="py-3 px-4 border shadow" data-cy="next" type="submit">{{ __(submitButtonText) }}</button>
         </div>
-        <div class="buttons--right"><a class="py-3 px-4 button-link transparent full-width" href="{{ cancelUrl }}"><img src="/img/times-circle.svg" aria-hidden="true" /><span>{{ __('start_over') }}</span></a></div>
+        <div class="buttons--right"><a class="py-3 px-4 button-link transparent full-width" href="{{ cancelUrl }}"><img src="/img/times-circle.svg" alt="" /><span>{{ __('start_over') }}</span></a></div>
     </div>
 {% endmacro %}
 


### PR DESCRIPTION
Resolves #209 , Resolves #212 , Resolves #210  

- There was an issue with having a style tag in a noscript. Technically it would be okay to move it to the header, but to be safe, I changed up the logic for display on the back link button. By default it has a class `no-js` which hides it. And then in the script we remove that class (which would only happen with JS enabled).

If we feel like we're going to do this to more elements, worth maybe setting this class on/off on the body.

- Add `role="link"` to the back button.  I didn't make it an anchor tag because it would have an empty href, as we're just using js to navigate back. So it is technically a button as you click it, and it does something.

- Add empty alt tags to the icons (we had aria-hidden, but I guess empty alt tags have more broader application)

- Also added a script to just open up cypress and run locally. Happy to remove if we don't feel it's useful though.