### PR TITLE
list of blue items on results page is now a list.

### DIFF
--- a/views/macros/benefit-result.njk
+++ b/views/macros/benefit-result.njk
@@ -1,7 +1,9 @@
 {% macro benefitResult(id, header, preamble, button, boxes) %}
 <div class="m-5 p-5 shadow-result">
     <h2 class="text-2xl font-bold mb-6" id="{{ id }}">{{ header }}</h2>
+    <ul class="list-none list-outside pl-0">
     {% for box in boxes %}
+        <li>
         <div class="bg-blue-200 p-5 m-1 text-blue-800">
             <p class="relative m-0 pl-8">
                 <svg class="w-6 h-6 mt-1 -ml-8 absolute fill-current" fill="none" aria-hidden="true" width="17" height="16" viewBox="0 0 17 16" xmlns="http://www.w3.org/2000/svg">
@@ -10,7 +12,9 @@
                 <strong>{{ box | safe }}</strong>
             </p>
         </div>
+        </li>
     {% endfor %}
+    </ul>
     <div class="pb-5 mt-6">
         {{ preamble | safe}}
     </div>


### PR DESCRIPTION
Added the blue items in the benefit results to a UL.

They should look identical.

Closes #205 

Before: 
![image](https://user-images.githubusercontent.com/87738/79238097-f9a99700-7e3c-11ea-96a9-ac4d82303b28.png)

After: 
![image](https://user-images.githubusercontent.com/87738/79238087-f57d7980-7e3c-11ea-85ce-cfc0874c676b.png)

