### PR TITLE
Error messages and focus colour

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -4,7 +4,7 @@ $color-blue-dark: #284162;
 $color-blue-light: #335075;
 $color-banner-blue: #4B98B2;
 $color-banner-blue-light: #DFF8FD;
-$color-yellow: #ffbf47;
+$color-yellow: #C78100;
 $color-white: #ffffff;
 $color-black: #000000;
 $color-red: #af3c43;

--- a/views/macros/radios.njk
+++ b/views/macros/radios.njk
@@ -3,6 +3,9 @@
         <fieldset class="fieldset">
             <legend class="fieldset__legend">
                 {% if attributes.required %}<span aria-hidden="true" class="required">*</span>{% endif %} {{ question }} {% if attributes.required %} <span class="required">{{ __("required")}}</span>{% endif %}
+                {% if errors and errors[key] %}
+                    {{ validationMessage(errors[key].msg, key) }}
+                {% endif %}
             </legend>
             {% if attributes.hint %}
                 <span class="form-message" id="{{ key }}-hint">
@@ -14,9 +17,6 @@
                 </span>
             {% endif %}
             <div class="multiple-choice multiple-choice--radios" id="{{ key }}">
-                {% if errors and errors[key] %}
-                    {{ validationMessage(errors[key].msg, key) }}
-                {% endif %}
                 {% for item in values %}
                 {% set itemId %}{{ key }}{{ item.value }}{%endset%}
                     <div class="multiple-choice__item">


### PR DESCRIPTION
Resolves #206 , Resolves #211 
![image](https://user-images.githubusercontent.com/6607541/79238197-1940bf80-7e3d-11ea-8669-c33d78d7cdd3.png)

- Move error messages into the legend
- Change yellow colour, to darker colour to meet accessibility standards for focus styles (we're only using the yellow for focus in our app)

For whatever reason I can't update the font-weight in the legend. So the error message gets the same font-weight. Putting the PR up because it still solves the accessibility issue, and I have a similar issue up (#163 )