### PR TITLE
Add page-specific html titles

### DIFF
--- a/routes/question-ccb/question-ccb.controller.js
+++ b/routes/question-ccb/question-ccb.controller.js
@@ -6,7 +6,9 @@ module.exports = (app, route) => {
 
   route.draw(app)
     .get((req, res) => {
-      res.render(name, routeUtils.getViewData(req, {}))
+      res.render(name, routeUtils.getViewData(req, {
+        title: res.__("ccb.title"),
+      }))
     })
     .post(route.applySchema(Schema), route.doRedirect())
 }

--- a/routes/question-gross-income/question-gross-income.controller.js
+++ b/routes/question-gross-income/question-gross-income.controller.js
@@ -6,12 +6,14 @@ module.exports = (app, route) => {
 
   route.draw(app)
     .get((req, res) => {
-      res.render(name, routeUtils.getViewData(req, {}))
+      res.render(name, routeUtils.getViewData(req, {
+        title: res.__('gross_income.title'),
+      }))
     })
     .post(route.applySchema(Schema), (req, res) => {
-      if(req.session.formdata.some_income && req.session.formdata.some_income === 'retired') {
+      if (req.session.formdata.some_income && req.session.formdata.some_income === 'retired') {
         return res.redirect(res.locals.routePath('question-rrif'))
-      } 
+      }
 
       return res.redirect(res.locals.routePath('question-mortgage-payments'))
     })

--- a/routes/question-gross-income/question-gross-income.njk
+++ b/routes/question-gross-income/question-gross-income.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-    <h1>{{__('gross_income.title')}}</h1>
+    <h1>{{ __('gross_income.title') }}</h1>
     <div>
         <form novalidate method="post">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/routes/question-lost-job/question-lost-job.controller.js
+++ b/routes/question-lost-job/question-lost-job.controller.js
@@ -6,7 +6,9 @@ module.exports = (app, route) => {
 
   route.draw(app)
     .get((req, res) => {
-      res.render(name, routeUtils.getViewData(req, {}))
+      res.render(name, routeUtils.getViewData(req, {
+        title: res.__('lost_job.title'),
+      }))
     })
     .post(route.applySchema(Schema), postLostJob)
 }

--- a/routes/question-mortgage-payments/question-mortgage-payments.controller.js
+++ b/routes/question-mortgage-payments/question-mortgage-payments.controller.js
@@ -6,7 +6,9 @@ module.exports = (app, route) => {
 
   route.draw(app)
     .get((req, res) => {
-      res.render(name, routeUtils.getViewData(req, {}))
+      res.render(name, routeUtils.getViewData(req, {
+        title: res.__("mortgage_payments.title"),
+      }))
     })
     .post(route.applySchema(Schema), route.doRedirect())
 }

--- a/routes/question-mortgage-payments/question-mortgage-payments.controller.js
+++ b/routes/question-mortgage-payments/question-mortgage-payments.controller.js
@@ -7,7 +7,7 @@ module.exports = (app, route) => {
   route.draw(app)
     .get((req, res) => {
       res.render(name, routeUtils.getViewData(req, {
-        title: res.__("mortgage_payments.title"),
+        title: res.__('mortgage_payments.title'),
       }))
     })
     .post(route.applySchema(Schema), route.doRedirect())

--- a/routes/question-mortgage-payments/question-mortgage-payments.njk
+++ b/routes/question-mortgage-payments/question-mortgage-payments.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-    <h1> {{ __("mortgage_payments.title") }} </h1>
+    <h1> {{ __('mortgage_payments.title') }} </h1>
     <div>
         <form novalidate method="post">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/routes/question-rrif/question-rrif.controller.js
+++ b/routes/question-rrif/question-rrif.controller.js
@@ -6,7 +6,9 @@ module.exports = (app, route) => {
 
   route.draw(app)
     .get((req, res) => {
-      res.render(name, routeUtils.getViewData(req, {}))
+      res.render(name, routeUtils.getViewData(req, {
+        title: res.__('rrif.title'),
+      }))
     })
     .post(route.applySchema(Schema), (req, res) => {
       return res.redirect(res.locals.routePath('question-mortgage-payments'))

--- a/routes/question-rrif/question-rrif.njk
+++ b/routes/question-rrif/question-rrif.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-    <h1>{{__('rrif.title')}}</h1>
+    <h1>{{ __('rrif.title') }}</h1>
     <div>
         <form novalidate method="post">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/routes/question-student-debt/question-student-debt.controller.js
+++ b/routes/question-student-debt/question-student-debt.controller.js
@@ -7,7 +7,7 @@ module.exports = (app, route) => {
   route.draw(app)
     .get((req, res) => {
       res.render(name, routeUtils.getViewData(req, {
-        title: res.__("student_debt.title"),
+        title: res.__('student_debt.title'),
       }))
     })
     .post(route.applySchema(Schema), route.doRedirect())

--- a/routes/question-student-debt/question-student-debt.controller.js
+++ b/routes/question-student-debt/question-student-debt.controller.js
@@ -6,7 +6,9 @@ module.exports = (app, route) => {
 
   route.draw(app)
     .get((req, res) => {
-      res.render(name, routeUtils.getViewData(req, {}))
+      res.render(name, routeUtils.getViewData(req, {
+        title: res.__("student_debt.title"),
+      }))
     })
     .post(route.applySchema(Schema), route.doRedirect())
 }

--- a/routes/question-student-debt/question-student-debt.njk
+++ b/routes/question-student-debt/question-student-debt.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-    <h1>{{ __("student_debt.title") }}</h1>
+    <h1>{{ __('student_debt.title') }}</h1>
     <div>
         <form novalidate method="post">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/routes/question-your-situation-no-income/question-your-situation-no-income.controller.js
+++ b/routes/question-your-situation-no-income/question-your-situation-no-income.controller.js
@@ -6,7 +6,9 @@ module.exports = (app, route) => {
 
   route.draw(app)
     .get((req, res) => {
-      res.render(name, routeUtils.getViewData(req, {}))
+      res.render(name, routeUtils.getViewData(req, {
+        title: res.__('no_income.title'),
+      }))
     })
     .post(route.applySchema(Schema), postNoIncome)
 }

--- a/routes/question-your-situation-no-income/question-your-situation-no-income.njk
+++ b/routes/question-your-situation-no-income/question-your-situation-no-income.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-    <h1>{{__('no_income.title')}}</h1>
+    <h1>{{ __('no_income.title') }}</h1>
     <div>
         <form novalidate method="post">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/routes/question-your-situation-some-income/question-your-situation-some-income.controller.js
+++ b/routes/question-your-situation-some-income/question-your-situation-some-income.controller.js
@@ -6,7 +6,9 @@ module.exports = (app, route) => {
 
   route.draw(app)
     .get((req, res) => {
-      res.render(name, routeUtils.getViewData(req, {}))
+      res.render(name, routeUtils.getViewData(req, {
+        title: res.__('some_income.title'),
+      }))
     })
     .post(route.applySchema(Schema), postSomeIncome)
 }
@@ -16,9 +18,9 @@ const postSomeIncome = (req, res) => {
   if (['hours-reduced', 'employed-lost-a-job', 'quarantine'].includes(req.body.some_income)) {
     return res.redirect(res.locals.routePath('question-mortgage-payments'))
   }
-  
+
   if (req.body.some_income === 'retired') {
     return res.redirect(res.locals.routePath('question-gross-income'))
   }
-  
+
 }

--- a/routes/question-your-situation-some-income/question-your-situation-some-income.njk
+++ b/routes/question-your-situation-some-income/question-your-situation-some-income.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-    <h1>{{__('some_income.title')}}</h1>
+    <h1>{{ __('some_income.title') }}</h1>
     <div>
         <form novalidate method="post">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/routes/question-your-situation-unchanged-income/question-your-situation-unchanged-income.controller.js
+++ b/routes/question-your-situation-unchanged-income/question-your-situation-unchanged-income.controller.js
@@ -6,18 +6,20 @@ module.exports = (app, route) => {
 
   route.draw(app)
     .get((req, res) => {
-      res.render(name, routeUtils.getViewData(req, {}))
+      res.render(name, routeUtils.getViewData(req, {
+        title: res.__('unchanged_income.title'),
+      }))
     })
     .post(route.applySchema(Schema), postUnchangedIncome)
 }
 
 const postUnchangedIncome = (req, res) => {
-  if (['wfh','paid-leave'].includes(req.body.unchanged_income)) {
+  if (['wfh', 'paid-leave'].includes(req.body.unchanged_income)) {
     return res.redirect(res.locals.routePath('question-mortgage-payments'))
   }
 
-  if(req.body.unchanged_income === 'retired') {
+  if (req.body.unchanged_income === 'retired') {
     return res.redirect(res.locals.routePath('question-rrif'))
   }
-  
+
 }

--- a/routes/question-your-situation-unchanged-income/question-your-situation-unchanged-income.njk
+++ b/routes/question-your-situation-unchanged-income/question-your-situation-unchanged-income.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-    <h1>{{__('unchanged_income.title')}}</h1>
+    <h1>{{ __('unchanged_income.title') }}</h1>
     <div>
         <form novalidate method="post">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/routes/results/results.controller.js
+++ b/routes/results/results.controller.js
@@ -9,12 +9,22 @@ module.exports = (app, route) => {
     .get((req, res) => {
       const data = getSessionData(req)
       const benefits = getBenefits(data);
+      let title = res.__n("results_title", benefits.length);
+
+      if (getNoCerb(data)) {
+        title = res.__("results_title_no_cerb");
+      }
+
+      if (benefits.length === 0) {
+        title = res.__("results_title_no_results");
+      }
 
       res.render(name, routeUtils.getViewData(req, {
         benefits: benefits,
         no_results: benefits.length === 0,
         no_cerb: getNoCerb(data),
         hideBackButton: true,
+        title: title,
       }))
     })
     .post(route.applySchema(Schema), route.doRedirect())

--- a/routes/results/results.controller.js
+++ b/routes/results/results.controller.js
@@ -9,14 +9,14 @@ module.exports = (app, route) => {
     .get((req, res) => {
       const data = getSessionData(req)
       const benefits = getBenefits(data);
-      let title = res.__n("results_title", benefits.length);
+      let title = res.__n('results_title', benefits.length);
 
       if (getNoCerb(data)) {
-        title = res.__("results_title_no_cerb");
+        title = res.__('results_title_no_cerb');
       }
 
       if (benefits.length === 0) {
-        title = res.__("results_title_no_results");
+        title = res.__('results_title_no_results');
       }
 
       res.render(name, routeUtils.getViewData(req, {

--- a/routes/results/results.njk
+++ b/routes/results/results.njk
@@ -11,13 +11,13 @@
     </div>
 
     {% if no_cerb %}
-        <h1>{{ __("results_title_no_cerb") }}</h1>
-        <p>{{ __("results.no_cerb.preamble") }}</p>
+        <h1>{{ __('results_title_no_cerb') }}</h1>
+        <p>{{ __('results.no_cerb.preamble') }}</p>
     {% elif no_results %}
-        <h1>{{ __("results_title_no_results") }}</h1>
-        <p>{{ __("results.no_results.preamble") }}</p>
+        <h1>{{ __('results_title_no_results') }}</h1>
+        <p>{{ __('results.no_results.preamble') }}</p>
     {% else %}
-        <h1>{{ __n("results_title", benefits.length) }}</h1>
+        <h1>{{ __n('results_title', benefits.length) }}</h1>
     {% endif %}
 
     {% if not data.lost_job %}

--- a/routes/start/start.controller.js
+++ b/routes/start/start.controller.js
@@ -20,6 +20,9 @@ module.exports = (app, route) => {
 
   route.draw(app).get(async (req, res) => {
     req.session = null
-    res.render(name, routeUtils.getViewData(req, { hideBackButton: true }))
+    res.render(name, routeUtils.getViewData(req, {
+      hideBackButton: true,
+      title: res.__('start.subtitle'),
+    }))
   })
 }

--- a/views/base.njk
+++ b/views/base.njk
@@ -20,7 +20,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
         <link href="https://fonts.googleapis.com/css?family=Lato:700|Noto+Sans:400,700&amp;display=fallback" rel="stylesheet">
         <link rel="stylesheet" href="/dist/css/styles.css">
-        <title>{{ __('app.title') }}</title>
+        <title>{{ title }} — {{ __('app.title') }}</title>
     </head>
     <body>
         <nav>

--- a/views/base.njk
+++ b/views/base.njk
@@ -20,7 +20,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
         <link href="https://fonts.googleapis.com/css?family=Lato:700|Noto+Sans:400,700&amp;display=fallback" rel="stylesheet">
         <link rel="stylesheet" href="/dist/css/styles.css">
-        <title>{{ title }} — {{ __('app.title') }}</title>
+        <title>{% if(title) %}{{ title }} — {% endif %}{{ __('app.title') }}</title>
     </head>
     <body>
         <nav>


### PR DESCRIPTION
Closes #208 

Adds relevant unique page titles to every page. Basically just prepends the current page title to the `<title>` attribute by passing it into the view template as `title`:

![image](https://user-images.githubusercontent.com/1187115/79244595-13e77300-7e45-11ea-94c2-00ef899dfd08.png)

If the title is not passed, the prefix does not display and just the default page title renders.

The Start page uses the page subtitle as prefix, since the page title is the same as the default.

The Results page displays a different page title depending on the contents of the page.