### PR TITLE
Add option for h3 headerSize in benefit-result

### DIFF
--- a/views/benefits/gst_credit.njk
+++ b/views/benefits/gst_credit.njk
@@ -9,5 +9,6 @@
     [
         __("gst_credit.box1"),
         __("gst_credit.box2")
-    ]
+    ],
+    "h3"
 )}}

--- a/views/macros/benefit-result.njk
+++ b/views/macros/benefit-result.njk
@@ -1,6 +1,10 @@
-{% macro benefitResult(id, header, preamble, button, boxes) %}
+{% macro benefitResult(id, header, preamble, button, boxes, headerSize="h2") %}
 <div class="m-5 p-5 shadow-result">
-    <h2 class="text-2xl font-bold mb-6" id="{{ id }}">{{ header }}</h2>
+    {% if headerSize === "h3" %}
+        <h3 class="text-2xl font-bold mb-6" id="{{ id }}">{{ header }}</h2>
+    {% else %}
+        <h2 class="text-2xl font-bold mb-6" id="{{ id }}">{{ header }}</h2>
+    {% endif %}
     <ul class="list-none list-outside pl-0">
     {% for box in boxes %}
         <li>


### PR DESCRIPTION
Resolves #214 

Add an option of headerSize to the benefit macro, defaulting to h2. At this time it only accounts for an h3, but we could easily extend this in the future for more headings (although I'd also question our page structure at that point). In any case, since it's just toggling between h2 and h3 for now, I opted to keep it simpler in the code, rather than accounting for all headings at this time (open to changing this).

To make the gst and h3, but still have it look like an h2 (since it falls under the h2 of "Other help available")

Still looks the same, just an h3 now

![image](https://user-images.githubusercontent.com/6607541/79244845-5a3cd200-7e45-11ea-9aeb-6cbc9810a0be.png)
