### PR TITLE
Set csrf config for production/other modes

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 // add app insights instrumentation
-if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY !== undefined) { 
+if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY !== undefined) {
   const appInsights = require("applicationinsights");
   appInsights.setup();
   appInsights.start();
@@ -43,12 +43,7 @@ app.use(require('./config/i18n.config').init)
 if (process.env.NODE_ENV !== 'test') {
   // CSRF setup
   app.use(
-    csrf({
-      cookie: true,
-      signed: true,
-      sameSite: true,
-      secure: true,
-    }),
+    csrf(require('./config/csrf.config')),
   )
 
   // append csrfToken to all responses

--- a/config/csrf.config.js
+++ b/config/csrf.config.js
@@ -1,0 +1,20 @@
+const getCsrfConfig = () => {
+  if (process.env.NODE_ENV === 'production') {
+    return {
+      cookie: {
+        sameSite: true,
+        secure: true,
+      },
+      signed: true,
+    }
+  }
+  return {
+    cookie: {
+      sameSite: true,
+    },
+    signed: true,
+  }
+}
+
+
+module.exports = getCsrfConfig();


### PR DESCRIPTION
Our Mozilla Observatory score takes a bit of a hit for not setting the samesite flag on our csrf token cookie

![image](https://user-images.githubusercontent.com/1187115/79466615-ceed4900-7fca-11ea-936c-60c222b31b17.png)

This PR fixes our config, and sets it differently for Production vs Development/other (only sets the Secure flag on production)