### PR TITLE
make the required text and error text a regular font-weight

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -71,6 +71,7 @@ h5,
 h6 {
   font-family: "Lato", sans-serif;
   line-height: 1.33;
+  font-weight: 600;
 }
 
 %page-container {

--- a/assets/scss/_forms.scss
+++ b/assets/scss/_forms.scss
@@ -99,11 +99,15 @@ form {
 
   fieldset legend,
   div:not(.multiple-choice__item) > label {
-    font-family: 'Lato', sans-serif;
+    font-family: "Lato", sans-serif;
     font-weight: 600;
     display: block;
     font-size: 1.07em;
     margin: 0;
+
+    span.required {
+      font-weight: 400;
+    }
   }
 
   .form-message {
@@ -111,6 +115,7 @@ form {
   }
 
   .validation-message {
+    font-weight: 400;
     color: $color-red;
   }
 

--- a/assets/scss/_forms.scss
+++ b/assets/scss/_forms.scss
@@ -100,7 +100,7 @@ form {
   fieldset legend,
   div:not(.multiple-choice__item) > label {
     font-family: "Lato", sans-serif;
-    font-weight: 600;
+    font-weight: 700;
     display: block;
     font-size: 1.07em;
     margin: 0;

--- a/views/base.njk
+++ b/views/base.njk
@@ -21,7 +21,7 @@
         {% if GITHUB_SHA %}<meta name="github-sha" content="{{ GITHUB_SHA }}">{% endif %}
         <link rel="shortcut icon" href="/favicon.png" type="image/x-icon" sizes="32x32">
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
-        <link href="https://fonts.googleapis.com/css?family=Lato:700|Noto+Sans:400,700&amp;display=fallback" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Lato:400,700|Noto+Sans:400,700&amp;display=fallback" rel="stylesheet">
         <link rel="stylesheet" href="/dist/css/styles.css">
         <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
Resolves #163 

Earlier, @michellengaiCDS asked if we could make the required text in the question a regular font-weight. I've done so, and also made the error message a regular font-weight (confirmed with Michelle that this is okay).

Had to import Lato in 400 to do so.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/6607541/79492739-64e69b00-7fee-11ea-86ff-c7d045e7c96c.png) | ![image](https://user-images.githubusercontent.com/6607541/79492466-0d482f80-7fee-11ea-8fb7-6eccf3576b78.png)  |

