### PR TITLE
Fix styling issues

### DIFF
--- a/assets/scss/_forms.scss
+++ b/assets/scss/_forms.scss
@@ -191,7 +191,7 @@ form {
 
       .button-link {
         display: flex;
-        justify-content: start;
+        justify-content: flex-start;
 
         @include md {
           justify-content: center;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -20,10 +20,10 @@ module.exports = {
   plugins: [
     require('@csstools/postcss-sass'),
     require('tailwindcss'),
+    require('autoprefixer'),
+    ...(process.env.NODE_ENV === 'production' ? [purgecss] : []),
     cssnano({
       preset: 'default',
     }),
-    require('autoprefixer'),
-    ...(process.env.NODE_ENV === 'production' ? [purgecss] : []),
   ],
 }


### PR DESCRIPTION
This fixes two styling issues.

The first was that Purgecss was clearing out some styles that were needed to make our checkboxes look right.

![image](https://user-images.githubusercontent.com/1187115/79754197-25b59400-82e5-11ea-9b8a-fd6bef1feaef.png)

The fix for this was to change the order of operations that are run by Postcss. CSSNano needs to run *after* Purgecss. Confirmed that after this change, file size is still roughly the same (19.5Kb)

The second issue was we were getting a warning during build time regarding a rule that was calling `start` rather than `flex-start`.