### PR TITLE
Track Slot Environment

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,10 @@
 // add app insights instrumentation
 if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY !== undefined) {
-  const appInsights = require("applicationinsights");
-  appInsights.setup();
-  appInsights.start();
+  var appInsights = require('applicationinsights')
+  appInsights.setup()
+  appInsights.setSendLiveMetrics(true)
+  appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] = process.env.SLOT_NAME
+  appInsights.start()
 }
 
 // import environment variables.
@@ -24,7 +26,7 @@ const { addNunjucksFilters } = require('./filters')
 const csp = require('./config/csp.config')
 const csrf = require('csurf')
 const uuidv4 = require('uuid').v4
-const crypto = require('crypto');
+const crypto = require('crypto')
 
 // check to see if we have a custom configRoutes function
 let { configRoutes, routes, locales } = require('./config/routes.config')
@@ -43,9 +45,7 @@ app.use(require('./config/i18n.config').init)
 
 if (process.env.NODE_ENV !== 'test') {
   // CSRF setup
-  app.use(
-    csrf(require('./config/csrf.config')),
-  )
+  app.use(csrf(require('./config/csrf.config')))
 
   // append csrfToken to all responses
   app.use(function (req, res, next) {
@@ -100,13 +100,11 @@ app.use(function (req, res, next) {
   next()
 })
 
-
-
 // middleware to redirect french paths to the french domain and english paths to the english domain
 /* istanbul ignore next */
 app.use(function (req, res, next) {
   // if not running on production azure, skip this
-  if (!process.env.APP_SERVICE) return next()
+  if (process.env.SLOT_NAME !== "default") return next()
 
   const domain = getDomain(req)
 
@@ -120,6 +118,7 @@ app.use(function (req, res, next) {
 
   next()
 })
+
 
 app.routes = configRoutes(app, routes, locales)
 
@@ -138,5 +137,27 @@ addNunjucksFilters(env)
 nunjucks.installJinjaCompat()
 
 app.set('view engine', 'njk')
+
+// Pass error information to res.locals
+app.use((err, req, res, next) => {
+  const errObj = {}
+
+  const status = err.status || err.statusCode || 500
+  res.statusCode = status
+
+  errObj.status = status
+  if (err.message) errObj.message = err.message
+  if (err.stack) errObj.stack = err.stack
+  if (err.code) errObj.code = err.code
+  if (err.name) errObj.name = err.name
+  if (err.type) errObj.type = err.type
+
+  if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
+    appInsights.trackeException({exception: errObj})
+  }
+
+  res.locals.err = errObj
+  next(err)
+})
 
 module.exports = app

--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 // add app insights instrumentation
+// istanbul ignore next
 if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY !== undefined) {
   var appInsights = require('applicationinsights')
   appInsights.setup()
@@ -43,6 +44,8 @@ app.use(express.urlencoded({ extended: false }))
 app.use(cookieParser(process.env.app_session_secret))
 app.use(require('./config/i18n.config').init)
 
+// ignore code coverage since this won't run in test mode
+// istanbul ignore next
 if (process.env.NODE_ENV !== 'test') {
   // CSRF setup
   app.use(csrf(require('./config/csrf.config')))
@@ -139,6 +142,7 @@ nunjucks.installJinjaCompat()
 app.set('view engine', 'njk')
 
 // Pass error information to res.locals
+// istanbul ignore next
 app.use((err, req, res, next) => {
   const errObj = {}
 

--- a/config/cookieSession.config.js
+++ b/config/cookieSession.config.js
@@ -20,7 +20,7 @@ const cookieSessionConfig = {
 }
 
 // if running on Azure, set the cookie domain to .alpha.canada.ca
-if (process.env.APP_SERVICE) {
+if (process.env.SLOT_NAME !== "default") {
   cookieSessionConfig.domain = '.alpha.canada.ca'
 }
 

--- a/config/cookieSession.config.js
+++ b/config/cookieSession.config.js
@@ -20,6 +20,7 @@ const cookieSessionConfig = {
 }
 
 // if running on Azure, set the cookie domain to .alpha.canada.ca
+// istanbul ignore next
 if (process.env.SLOT_NAME !== "default") {
   cookieSessionConfig.domain = '.alpha.canada.ca'
 }

--- a/config/csrf.config.js
+++ b/config/csrf.config.js
@@ -1,3 +1,4 @@
+// istanbul ignore file 
 const getCsrfConfig = () => {
   if (process.env.NODE_ENV === 'production') {
     return {

--- a/routes/start/start.controller.js
+++ b/routes/start/start.controller.js
@@ -8,6 +8,7 @@ module.exports = (app, route) => {
     const domain = getDomain(req)
 
     // if on the French domain, redirect to the /fr start page
+    // istanbul ignore next
     if (domain.includes(process.env.DOMAIN_FR)) {
       return res.redirect(`${domain}${route.path.fr}`)
     }

--- a/routes/start/start.controller.spec.js
+++ b/routes/start/start.controller.spec.js
@@ -18,6 +18,11 @@ jest.mock('../../utils/load.helpers.js', () => ({
   },
 }))
 
+test ('User gets redirect when hitting /', async () => { 
+  const response = await request(app).get('/')
+  expect(response.statusCode).toBe(302)
+})
+
 test('Can send get request to start route and have js src set', async () => {
   const route = app.routes.get('start')
   const response = await request(app).get(route.path.en)

--- a/terraform/azure/app-insights.tf
+++ b/terraform/azure/app-insights.tf
@@ -4,10 +4,3 @@ resource "azurerm_application_insights" "covid-benefit" {
   resource_group_name = azurerm_resource_group.resource_group.name
   application_type    = "Node.JS"
 }
-
-resource "azurerm_application_insights" "staging" {
-  name                = "${var.name}.app_insight-staging"
-  location            = azurerm_resource_group.resource_group.location
-  resource_group_name = azurerm_resource_group.resource_group.name
-  application_type    = "Node.JS"
-}

--- a/terraform/azure/app-service-docker.tf
+++ b/terraform/azure/app-service-docker.tf
@@ -36,6 +36,7 @@ resource "azurerm_app_service" "app_service" {
     "DOCKER_REGISTRY_SERVER_USERNAME" = azurerm_container_registry.container_registry.admin_username
     #"DOCKER_REGISTRY_SERVER_PASSWORD" = azurerm_container_registry.container_registry.admin_password
     "DOCKER_REGISTRY_SERVER_PASSWORD" = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.docker_password.name}/${azurerm_key_vault_secret.docker_password.version})"
+    "SLOT_NAME"                       = "default"
   
   }
 
@@ -66,13 +67,14 @@ resource "azurerm_app_service_slot" "staging" {
   }
 
   app_settings = {
-    "APPINSIGHTS_INSTRUMENTATIONKEY"  = azurerm_application_insights.staging.instrumentation_key
+    "APPINSIGHTS_INSTRUMENTATIONKEY"  = azurerm_application_insights.covid-benefit.instrumentation_key
     "APP_SERVICE"                     = "true"
     "DOCKER_ENABLE_CI"                = "true"
     "DOCKER_REGISTRY_SERVER_URL"      = "https://${azurerm_container_registry.container_registry.login_server}"
     "DOCKER_REGISTRY_SERVER_USERNAME" = azurerm_container_registry.container_registry.admin_username
     #"DOCKER_REGISTRY_SERVER_PASSWORD" = azurerm_container_registry.container_registry.admin_password
     "DOCKER_REGISTRY_SERVER_PASSWORD" = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.docker_password.name}/${azurerm_key_vault_secret.docker_password.version})"
+    "SLOT_NAME"                       = "staging"
   }
 
   logs {


### PR DESCRIPTION
Merge to one app insight settings and use the cloud role to differentiate slots
Use SLOT_NAME instead of APP SETTINGS for cookie creation
Send live stats to appinsights
Log error information in Morgan logs.

Ignore code coverage for lines that can't be hit during testing.