### PR TITLE
Run e2e tests in both English and French

### DIFF
--- a/cypress/integration/a11y.spec.js
+++ b/cypress/integration/a11y.spec.js
@@ -1,83 +1,94 @@
+const { route } = require('../routeHelper');
+
 /* eslint-disable no-undef */
 describe('Result Page Only tests', () => {
-  it('should display an error when navigating directly to results page', () => {
-    cy.visit('/en/results')
-    cy.get('[data-cy=missed-questions]')
-    cy.reportA11y()
-  })
+  ['en', 'fr'].forEach((lang) => {
+    describe('Language: ' + lang, () => {
+      it('should display an error when navigating directly to results page', () => {
+        cy.visit(route('results', lang))
+        cy.get('[data-cy=missed-questions]')
+        cy.reportA11y()
+      })
 
-  it('should display GST Benefit no matter what', () => {
-    cy.visit('/en/results')
-    cy.get('#gst_credit')
-    cy.reportA11y()
+      it('should display GST Benefit no matter what', () => {
+        cy.visit(route('results', lang))
+        cy.get('#gst_credit')
+        cy.reportA11y()
+      })
+    })
   })
 })
 
 describe('Paths and Benefits', () => {
-  beforeEach(() => {
-    cy.visit('/')
-    cy.reportA11y()
-    cy.get('[data-cy=start]').click()
-  })
+  ['en', 'fr'].forEach((lang) => {
+    describe('Language: ' + lang, () => {
 
-  it('EI Sickness CERB, Mortgage, Student Loans, CCB', () => {
-    cy.answerQuestion('#lost_joblost-all-income')
-    cy.answerQuestion('#no_incomesick-or-quarantined')
-    cy.answerQuestion('#mortgage_paymentsyes-mortgage')
-    cy.answerQuestion('#ccbyes')
-    cy.answerQuestion('#student_debtyes')
-    cy.reportA11y()
-    cy.get('[data-cy=benefit-list]').children().should('have.length', '4')
-    cy.get('#ei_sickness_cerb')
-    cy.get('#mortgage_deferral')
-    cy.get('#student_loan')
-    cy.get('#ccb_payment')
-  })
+      beforeEach(() => {
+        cy.visit('/' + lang)
+        cy.reportA11y()
+        cy.get('[data-cy=start]').click()
+      })
 
-  it('CERB', () => {
-    cy.answerQuestion('#lost_joblost-all-income')
-    cy.answerQuestion('#no_incomeself-employed-closed')
-    cy.answerQuestion('#mortgage_paymentsno')
-    cy.answerQuestion('#ccbno')
-    cy.answerQuestion('#student_debtno')
-    cy.reportA11y()
-    cy.get('[data-cy=benefit-list]').children().should('have.length', '1')
-    cy.get('#cerb')
-  })
+      it('EI Sickness CERB, Mortgage, Student Loans, CCB', () => {
+        cy.answerQuestion('#lost_joblost-all-income')
+        cy.answerQuestion('#no_incomesick-or-quarantined')
+        cy.answerQuestion('#mortgage_paymentsyes-mortgage')
+        cy.answerQuestion('#ccbyes')
+        cy.answerQuestion('#student_debtyes')
+        cy.reportA11y()
+        cy.get('[data-cy=benefit-list]').children().should('have.length', '4')
+        cy.get('#ei_sickness_cerb')
+        cy.get('#mortgage_deferral')
+        cy.get('#student_loan')
+        cy.get('#ccb_payment')
+      })
 
-  it('EI Regular Cerb', () => {
-    cy.answerQuestion('#lost_joblost-some-income')
-    cy.answerQuestion('#some_incomehours-reduced')
-    cy.answerQuestion('#reduced_income1000_or_less')
-    cy.answerQuestion('#mortgage_paymentsno')
-    cy.answerQuestion('#ccbno')
-    cy.answerQuestion('#student_debtno')
-    cy.reportA11y()
-    cy.get('[data-cy=benefit-list]').children().should('have.length', '1')
-    cy.get('#ei_regular_cerb')
-  })
+      it('CERB', () => {
+        cy.answerQuestion('#lost_joblost-all-income')
+        cy.answerQuestion('#no_incomeself-employed-closed')
+        cy.answerQuestion('#mortgage_paymentsno')
+        cy.answerQuestion('#ccbno')
+        cy.answerQuestion('#student_debtno')
+        cy.reportA11y()
+        cy.get('[data-cy=benefit-list]').children().should('have.length', '1')
+        cy.get('#cerb')
+      })
 
-  it('RRIF', () => {
-    cy.answerQuestion('#lost_joblost-some-income')
-    cy.answerQuestion('#some_incomeretired')
-    cy.answerQuestion('#gross_income4999_or_less')
-    cy.answerQuestion('#rrifyes')
-    cy.answerQuestion('#mortgage_paymentsno')
-    cy.answerQuestion('#ccbno')
-    cy.answerQuestion('#student_debtno')
-    cy.reportA11y()
-    cy.get('[data-cy=benefit-list]').children().should('have.length', '1')
-    cy.get('#rrif')
-  })
+      it('EI Regular Cerb', () => {
+        cy.answerQuestion('#lost_joblost-some-income')
+        cy.answerQuestion('#some_incomehours-reduced')
+        cy.answerQuestion('#reduced_income1000_or_less')
+        cy.answerQuestion('#mortgage_paymentsno')
+        cy.answerQuestion('#ccbno')
+        cy.answerQuestion('#student_debtno')
+        cy.reportA11y()
+        cy.get('[data-cy=benefit-list]').children().should('have.length', '1')
+        cy.get('#ei_regular_cerb')
+      })
 
-  it('Rent Help', () => {
-    cy.answerQuestion('#lost_joblost-no-income')
-    cy.answerQuestion('#unchanged_incomewfh')
-    cy.answerQuestion('#mortgage_paymentsyes-rent')
-    cy.answerQuestion('#ccbno')
-    cy.answerQuestion('#student_debtno')
-    cy.reportA11y()
-    cy.get('[data-cy=benefit-list]').children().should('have.length', '1')
-    cy.get('#rent_help')
+      it('RRIF', () => {
+        cy.answerQuestion('#lost_joblost-some-income')
+        cy.answerQuestion('#some_incomeretired')
+        cy.answerQuestion('#gross_income4999_or_less')
+        cy.answerQuestion('#rrifyes')
+        cy.answerQuestion('#mortgage_paymentsno')
+        cy.answerQuestion('#ccbno')
+        cy.answerQuestion('#student_debtno')
+        cy.reportA11y()
+        cy.get('[data-cy=benefit-list]').children().should('have.length', '1')
+        cy.get('#rrif')
+      })
+
+      it('Rent Help', () => {
+        cy.answerQuestion('#lost_joblost-no-income')
+        cy.answerQuestion('#unchanged_incomewfh')
+        cy.answerQuestion('#mortgage_paymentsyes-rent')
+        cy.answerQuestion('#ccbno')
+        cy.answerQuestion('#student_debtno')
+        cy.reportA11y()
+        cy.get('[data-cy=benefit-list]').children().should('have.length', '1')
+        cy.get('#rent_help')
+      })
+    })
   })
 })

--- a/cypress/integration/errors.spec.js
+++ b/cypress/integration/errors.spec.js
@@ -1,50 +1,58 @@
+const { route } = require('../routeHelper');
+
 /* eslint-disable no-undef */
-function testError(route, numberOfExpectedErrors) {
+function testError(name, lang, numberOfExpectedErrors) {
   const numErrors = numberOfExpectedErrors || 1
-  cy.visit(`en${route}`)
+  const path = route(name, lang);
+
+  cy.visit(path)
   cy.get('[data-cy=next]').click()
   cy.get('[data-cy=errors]').children().should('have.length', numErrors)
   cy.reportA11y()
 }
 
 describe('Error Pages', () => {
-  it('Lost Job', () => {
-    testError('/lost-job')
-  })
+  ['en', 'fr'].forEach((lang) => {
+    describe('Language: ' + lang, () => {
+      it('Lost Job', () => {
+        testError('question-lost-job', lang)
+      })
 
-  it('No Income', () => {
-    testError('/your-situation/no-income')
-  })
+      it('No Income', () => {
+        testError('question-your-situation-no-income', lang)
+      })
 
-  it('Some Income', () => {
-    testError('/your-situation/some-income')
-  })
+      it('Some Income', () => {
+        testError('question-your-situation-some-income')
+      })
 
-  it('Unchanged Income', () => {
-    testError('/your-situation/unchanged-income')
-  })
+      it('Unchanged Income', () => {
+        testError('question-your-situation-unchanged-income', lang)
+      })
 
-  it('Mortgage Payments', () => {
-    testError('/mortgage-payments')
-  })
+      it('Mortgage Payments', () => {
+        testError('question-mortgage-payments', lang)
+      })
 
-  it('CCB', () => {
-    testError('/CCB')
-  })
+      it('CCB', () => {
+        testError('question-ccb', lang)
+      })
 
-  it('Student Debt', () => {
-    testError('/student-debt')
-  })
+      it('Student Debt', () => {
+        testError('question-student-debt', lang)
+      })
 
-  it('RRIF', () => {
-    testError('/RRIF')
-  })
+      it('RRIF', () => {
+        testError('question-rrif', lang)
+      })
 
-  it('Gross Income', () => {
-    testError('/gross-income')
-  })
+      it('Gross Income', () => {
+        testError('question-gross-income', lang)
+      })
 
-  it('Reduced Income', () => {
-    testError('/reduced-income')
+      it('Reduced Income', () => {
+        testError('question-reduced-income', lang)
+      })
+    })
   })
 })

--- a/cypress/routeHelper.js
+++ b/cypress/routeHelper.js
@@ -1,0 +1,18 @@
+const { routes } = require('../config/routes.config');
+
+const route = (name, lang) => {
+  if (!name) {
+    throw new Error('Route helper: missing name argument');
+  }
+
+  if (!lang) {
+    lang = 'en'
+  }
+
+  const route = routes.find(rt => rt.name === name);
+  return lang + route.path[lang];
+}
+
+module.exports = {
+  route,
+}


### PR DESCRIPTION
- Adds a route helper that tests can use to get route path by name
- Runs all tests using english and french urls

Note: I created a custom route helper because the one elsewhere in the app was not exactly portable ... with a little work to make it more robust, maybe we can replace the global helper with this one later.