### PR TITLE
Add visually hidden heading before language switch link

### DIFF
--- a/views/_includes/languageLink.njk
+++ b/views/_includes/languageLink.njk
@@ -1,10 +1,11 @@
 {% if route %}
-<div class="language-link">
-    {% if locale != 'fr' %}
-    <a href="{{route.path.fr}}" lang="fr">Français</a>
-    {% endif %}
-    {% if locale != 'en' %}
-    <a href="{{route.path.en}}" lang="en">English</a>
-    {% endif %}
-</div>
+    <h2 class="sr-only">{{ __("Language Selection") }}</h2>
+    <div class="language-link">
+        {% if locale != 'fr' %}
+            <a href="{{route.path.fr}}" lang="fr">Français</a>
+        {% endif %}
+        {% if locale != 'en' %}
+            <a href="{{route.path.en}}" lang="en">English</a>
+        {% endif %}
+    </div>
 {% endif %}


### PR DESCRIPTION
Addresses an item in the "a11y - Other items" issue, adding a visually hidden heading before the language switch link.