### PR TITLE
Adding dev slot and syncing with existing infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ cdk.out
 
 cdk/local-image
 credentials
+
+terraform/azure/secrets.auto.tfvars

--- a/terraform/azure/app-service-docker.tf
+++ b/terraform/azure/app-service-docker.tf
@@ -6,8 +6,12 @@ resource "azurerm_app_service_plan" "app_service_plan" {
   reserved            = true
 
   sku {
-    tier = "Standard"
-    size = "P1V2"
+    tier = "PremiumV2"
+    size = "P1v2"
+  }
+
+  tags = {
+    "project-code" = "esdc-covid-19-cds"
   }
 }
 
@@ -19,9 +23,8 @@ resource "azurerm_app_service" "app_service" {
   https_only          = "true"
 
   site_config {
-    #linux_fx_version = "DOCKER|${azurerm_container_registry.container_registry.login_server}/${var.docker_image}:${var.docker_image_tag}"
-    http2_enabled    = true
-    always_on        = true
+    http2_enabled = true
+    always_on     = true
   }
 
   identity {
@@ -31,13 +34,15 @@ resource "azurerm_app_service" "app_service" {
   app_settings = {
     "APPINSIGHTS_INSTRUMENTATIONKEY"  = azurerm_application_insights.covid-benefit.instrumentation_key
     "APP_SERVICE"                     = "true"
+    "AIRTABLE_API_KEY"                = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.airtable_api_key.name}/${azurerm_key_vault_secret.airtable_api_key.version})"
+    "AIRTABLE_BASE_ID"                = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.airtable_base_id.name}/${azurerm_key_vault_secret.airtable_base_id.version})"
     "DOCKER_ENABLE_CI"                = "true"
     "DOCKER_REGISTRY_SERVER_URL"      = "https://${azurerm_container_registry.container_registry.login_server}"
     "DOCKER_REGISTRY_SERVER_USERNAME" = azurerm_container_registry.container_registry.admin_username
     #"DOCKER_REGISTRY_SERVER_PASSWORD" = azurerm_container_registry.container_registry.admin_password
     "DOCKER_REGISTRY_SERVER_PASSWORD" = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.docker_password.name}/${azurerm_key_vault_secret.docker_password.version})"
     "SLOT_NAME"                       = "default"
-  
+
   }
 
   logs {
@@ -57,9 +62,9 @@ resource "azurerm_app_service_slot" "staging" {
   app_service_plan_id = azurerm_app_service_plan.app_service_plan.id
 
   site_config {
-    linux_fx_version = "DOCKER|${azurerm_container_registry.container_registry.login_server}/${var.docker_image}:staging"
-    http2_enabled    = true
-    always_on        = true
+    #linux_fx_version = "DOCKER|${azurerm_container_registry.container_registry.login_server}/${var.docker_image}:staging"
+    http2_enabled = true
+    always_on     = true
   }
 
   identity {
@@ -86,10 +91,55 @@ resource "azurerm_app_service_slot" "staging" {
     }
   }
 }
+
+
+resource "azurerm_app_service_slot" "dev" {
+  name                = "dev"
+  app_service_name    = azurerm_app_service.app_service.name
+  location            = azurerm_resource_group.resource_group.location
+  resource_group_name = azurerm_resource_group.resource_group.name
+  app_service_plan_id = azurerm_app_service_plan.app_service_plan.id
+
+  site_config {
+    #linux_fx_version = "DOCKER|${azurerm_container_registry.container_registry.login_server}/${var.docker_image}:staging"
+    http2_enabled = true
+    always_on     = true
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  app_settings = {
+    "APPINSIGHTS_INSTRUMENTATIONKEY"  = azurerm_application_insights.covid-benefit.instrumentation_key
+    "APP_SERVICE"                     = "true"
+    "DOCKER_ENABLE_CI"                = "true"
+    "DOCKER_REGISTRY_SERVER_URL"      = "https://${azurerm_container_registry.container_registry.login_server}"
+    "DOCKER_REGISTRY_SERVER_USERNAME" = azurerm_container_registry.container_registry.admin_username
+    #"DOCKER_REGISTRY_SERVER_PASSWORD" = azurerm_container_registry.container_registry.admin_password
+    "DOCKER_REGISTRY_SERVER_PASSWORD" = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.docker_password.name}/${azurerm_key_vault_secret.docker_password.version})"
+    "SLOT_NAME"                       = "dev"
+  }
+
+  logs {
+    http_logs {
+      file_system {
+        retention_in_days = 7
+        retention_in_mb   = 50
+      }
+    }
+  }
+}
+
+
 output "default_site_hostname" {
   value = azurerm_app_service.app_service.default_site_hostname
 }
 
 output "staging_site_hostname" {
   value = azurerm_app_service_slot.staging.default_site_hostname
+}
+
+output "development_site_hostname" {
+  value = azurerm_app_service_slot.dev.default_site_hostname
 }

--- a/terraform/azure/keyvault.tf
+++ b/terraform/azure/keyvault.tf
@@ -52,9 +52,35 @@ resource "azurerm_key_vault_access_policy" "staging_slot_identity" {
   depends_on = [azurerm_app_service_slot.staging]
 }
 
+resource "azurerm_key_vault_access_policy" "dev_slot_identity" {
+
+  key_vault_id = azurerm_key_vault.key_vault.id
+  object_id    = azurerm_app_service_slot.dev.identity.0.principal_id
+  tenant_id    = azurerm_app_service_slot.dev.identity.0.tenant_id
+  secret_permissions = [
+    "get",
+    "list",
+  ]
+  depends_on = [azurerm_app_service_slot.dev]
+}
+
 resource "azurerm_key_vault_secret" "docker_password" {
   name         = "dockerpword"
   value        = azurerm_container_registry.container_registry.admin_password
+  key_vault_id = azurerm_key_vault.key_vault.id
+  depends_on   = [azurerm_key_vault_access_policy.tf_identity]
+}
+
+resource "azurerm_key_vault_secret" "airtable_api_key" {
+  name         = "AirtableApiKey"
+  value        = var.airtable_api_key
+  key_vault_id = azurerm_key_vault.key_vault.id
+  depends_on   = [azurerm_key_vault_access_policy.tf_identity]
+}
+
+resource "azurerm_key_vault_secret" "airtable_base_id" {
+  name         = "AirtableBaseId"
+  value        = var.airtable_base_id
   key_vault_id = azurerm_key_vault.key_vault.id
   depends_on   = [azurerm_key_vault_access_policy.tf_identity]
 }

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -14,3 +14,12 @@ variable "docker_image" {
 variable "docker_image_tag" {
   description = "(Optional) Specify the tag to be deployed"
 }
+
+
+variable "airtable_api_key" {
+  description = "(Required) API Key for airtable shoudld be kept secret and in an a terraform variables file that isn't in git"
+}
+
+variable "airtable_base_id" {
+  description = "(Required) API Key for airtable shoudld be kept secret and in an a terraform variables file that isn't in git"
+}


### PR DESCRIPTION
Adds the Airtable api keys to the secret store. 
Adds a Dev Slot to the app service.
Terraform now requires a secrets.auto.tfvars file on the local machine with the airtable API and BASE ID.

Please note this work has already been applied to our prod instance. 

The new deploy workflow will come in a seperate PR. 