### PR TITLE
Add "datetime" attribute to <time> element near site footer

### DIFF
--- a/views/base.njk
+++ b/views/base.njk
@@ -54,7 +54,7 @@
                 {% include "_includes/feedback.njk" %}
 
                 {% if LAST_UPDATED %}
-                    <dl class="text-base mt-16"><dt class="inline-block">{{ __('date_modified') }} </dt><dd class="inline-block ml-2"><time property="dateModified">{{ LAST_UPDATED }}</time></dd></dl>
+                    <dl class="text-base mt-16"><dt class="inline-block">{{ __('date_modified') }} </dt><dd class="inline-block ml-2"><time datetime="{{ LAST_UPDATED }}">{{ LAST_UPDATED }}</time></dd></dl>
                 {% endif %}
             </main>
             {% include "_includes/footer.njk" %}


### PR DESCRIPTION
The HTML5 spec says that the one unique attribute of a `time` component
is called "datetime" and it gives a list of acceptable formats.

> The HTML <time> element represents a specific period in time. It may include the datetime attribute to translate dates into machine-readable format, allowing for better search engine results or custom features such as reminders.

Source:
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#Attributes

Removed the "property" attribute as it doesn't appear to be valid html5.