### PR TITLE
Restyle footer with Tailwind and mobile fix

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -88,7 +88,7 @@ h6 {
 main {
   @extend %page-container;
   padding: 0 $space-md;
-  padding-bottom: calc(#{$height-footer} + #{$space-lg});
+  
 
   h1 {
     border-bottom: 1px solid $color-red;

--- a/assets/scss/components/_footer.scss
+++ b/assets/scss/components/_footer.scss
@@ -1,86 +1,13 @@
-$footerInnerHeight: 35px;
-
-footer {
-  padding-top: $space-md;
-  border-top: 4px solid $color-blue-dark;
-  height: $height-footer;
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-
-  .page--container {
-    margin-bottom: $space-lg;
-  }
-
-  .footer-links {
-    font-size: 0.85em;
-
-    ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      margin-bottom: $space-xl;
-
-      @include sm {
-        margin-bottom: $space-md;
-      }
-    }
-
+.footer-links {
+  @include md {
     li {
-      margin-right: $space-sm;
-
       &::before {
         content: '\2022';
-        color: $color-blue-light;
-        display: inline-block;
-        // bullets are about 5px, so add space to compensate
-        width: calc(#{$space-sm} + 5px);
+        margin-right: .7em;
       }
 
-      @include sm {
-        &:first-of-type::before {
-          content: none;
-          width: 0;
-        }
-        display: inline-block;
-      }
-    }
-
-    a {
-      text-decoration: none;
-    }
-  }
-
-  .canada-wordmark {
-    margin-bottom: $space-md;
-    width: 147.2px;
-  }
-
-  @include md {
-    .page--container {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-end;
-
-      height: $footerInnerHeight;
-
-      .footer-links {
-        flex: 2;
-
-        ul {
-          // put the footer links on the same baseline as the Canada wordmark
-          margin-bottom: -$space-xxs;
-        }
-      }
-      .canada-wordmark {
-        flex: 1;
-        text-align: right;
-        margin-bottom: 0;
-        max-height: 100%;
-
-        img {
-          height: $footerInnerHeight;
-        }
+      &:first-of-type::before {
+        content: none;
       }
     }
   }

--- a/views/_includes/footer.njk
+++ b/views/_includes/footer.njk
@@ -1,20 +1,20 @@
 <footer class="border-0 bg-gray-100">
-    <div class="page--container">
-        <div class="footer-links">
-            <ul>
-                <li>
-                    <a href="{{ __('footer.contact') }}">{{ __('footer.contact.desc') }}</a>
+    <div class="page--container flex flex-row justify-between md:items-baseline pt-4 md:pt-10 pb-6 md:pb-10">
+        <nav class="footer-links md:w-4/5">
+            <ul class="p-0 text-base list-inside">
+                <li class="md:inline-block pr-4">
+                    <a href="{{ __('footer.contact') }}" class="no-underline hover:underline">{{ __('footer.contact.desc') }}</a>
                 </li>
-                <li>
-                    <a href={{ __('footer.privacy') }}>{{ __('footer.privacy.desc') }}</a>
+                <li class="md:inline-block pr-4">
+                    <a href={{ __('footer.privacy') }} class="no-underline hover:underline">{{ __('footer.privacy.desc') }}</a>
                 </li>
-                <li>
-                    <a href={{ __('footer.terms') }}>{{ __('footer.terms.desc') }}</a>
+                <li class="md:inline-block">
+                    <a href={{ __('footer.terms') }} class="no-underline hover:underline">{{ __('footer.terms.desc') }}</a>
                 </li>
             </ul>
-        </div>
-        <div class="canada-wordmark">
-            <img src="{{ asset('/img/wmms-blk.svg') }}" alt="{{ __('wordmark.alt') }}">
+        </nav>
+        <div class="md:w-1/5 md:relative">
+            <img src="{{ asset('/img/wmms-blk.svg') }}" alt="{{ __('wordmark.alt') }}" class="h-12 pt-2 md:absolute md:bottom-0 md:right-0">
         </div>
     </div>
 </footer>

--- a/views/_includes/footer.njk
+++ b/views/_includes/footer.njk
@@ -1,6 +1,6 @@
 <footer class="border-0 bg-gray-100 mt-8">
     <div class="page--container flex flex-row justify-between md:items-baseline pt-4 md:pt-10 pb-6 md:pb-10">
-        <nav class="footer-links md:w-4/5">
+        <div class="footer-links md:w-4/5">
             <ul class="p-0 text-base list-inside">
                 <li class="md:inline-block pr-4">
                     <a href="{{ __('footer.contact') }}" class="no-underline hover:underline">{{ __('footer.contact.desc') }}</a>
@@ -12,7 +12,7 @@
                     <a href={{ __('footer.terms') }} class="no-underline hover:underline">{{ __('footer.terms.desc') }}</a>
                 </li>
             </ul>
-        </nav>
+        </div>
         <div class="md:w-1/5 md:relative">
             <img src="{{ asset('/img/wmms-blk.svg') }}" alt="{{ __('wordmark.alt') }}" class="h-12 pt-2 md:absolute md:bottom-0 md:right-0">
         </div>

--- a/views/_includes/footer.njk
+++ b/views/_includes/footer.njk
@@ -1,4 +1,4 @@
-<footer class="border-0 bg-gray-100">
+<footer class="border-0 bg-gray-100 mt-8">
     <div class="page--container flex flex-row justify-between md:items-baseline pt-4 md:pt-10 pb-6 md:pb-10">
         <nav class="footer-links md:w-4/5">
             <ul class="p-0 text-base list-inside">


### PR DESCRIPTION
Closes #337 

Replace (most) of the Sass styles with Tailwind. Fixes an issue with the footer background on mobile.

![image](https://user-images.githubusercontent.com/1187115/80839527-71abe700-8bc9-11ea-9d20-7c783285a316.png)
