### PR TITLE
Fix firefox summary marker, add focus to summary

### DIFF
--- a/assets/scss/components/_details.scss
+++ b/assets/scss/components/_details.scss
@@ -1,25 +1,18 @@
 details {
   margin-bottom: $space-lg;
-  list-style-type: none;
   font-size: 0.875em;
 
   summary {
     color: $color-blue-dark;
     cursor: pointer;
-    // the little arrow disappears in firefox unless this is set explicitly
-    display: list-item;
-
-    &:focus {
-      outline: 0 !important;
-
-      > span {
-        @include focus($outlineOffset: 2px);
-      }
-    }
 
     // the summary element doesn't appear to accept underlined text
     > span {
       text-decoration: underline;
+    }
+
+    &:focus {
+      @include focus();
     }
 
     & ~ * {

--- a/views/_includes/feedback.njk
+++ b/views/_includes/feedback.njk
@@ -1,5 +1,5 @@
-<details class="w-full sm:w-2/3 lg:w-1/2">
-    <summary class="px-4 py-2 bg-gray-300 rounded inline-block">{{ __('feedback.button') }}</summary>
+<details class="w-full sm:w-1/2 md:w-3/5 lg:w-2/5">
+    <summary class="px-4 py-2 bg-gray-300 rounded text-center">{{ __('feedback.button') }}</summary>
     
     <form action="/{{ getLocale() }}/feedback" method="post" class="px-8 py-6 rounded border border-gray-300 bg-gray-200" id="feedback-form">
       <input type="hidden" name="_csrf" id="feedback-csrf" value="{{ csrfToken }}">


### PR DESCRIPTION
Closes #344 

Add focus style to the Feedback summary/details element.

Fix the display of the ::marker element on Firefox.