### PR TITLE
Fixing a11y issues on GST credit

### DIFF
--- a/views/benefits/gst_credit-en.njk
+++ b/views/benefits/gst_credit-en.njk
@@ -5,7 +5,23 @@
 
   <ul class="list-none list-outside pl-0">
     {{ blueLI("Automatic payment in April if you already receive the GST credit") }}
-    {{ blueLI("On average:<br>$400 for single people<br>$600 for couples") }}
+
+    <li>
+      <div class="bg-blue-200 p-5 m-1 text-blue-800">
+        <p class="relative m-0 pl-8 ">
+          <img src="{{ asset('/img/check-circle.svg') }}" class="w-6 h-6 mt-1 -ml-8 absolute fill-current" alt="">
+          <strong>On average:</strong>
+          <ul class='list-none  mt-2'>
+            <li>
+              <strong>$400 for single people</strong>
+            </li>
+            <li>
+              <strong>$600 for couples</strong>
+            </li>
+          </ul>
+        </p>
+      </div>
+    </li>
     {{ blueLI("Amount depends on your 2018 income taxes") }}
   </ul>
 

--- a/views/benefits/gst_credit-en.njk
+++ b/views/benefits/gst_credit-en.njk
@@ -1,7 +1,7 @@
 <div class="m-5 p-5 shadow-result">
-  <h2 class="text-2xl font-bold mb-6" id="gst_credit">
+  <h3 class="text-2xl font-bold mb-6" id="gst_credit">
     {{ __("gst_credit.header") }}
-  </h2>
+  </h3>
 
   <ul class="list-none list-outside pl-0">
     {{ blueLI("Automatic payment in April if you already receive the GST credit") }}


### PR DESCRIPTION
- Adds an Unordered List for displaying the average money amount (Closes #348) 
  -  I either had to unroll this instance of the macro, or change the macro so the text isn't wrapped in a strong. Strong tags can only containing phrasing tags, and UL is a flow tag. 

- Downgrades the GST header to an h3 (Closes #353 )
  - This was fixed in a previous change but got reverted when removed the benefit results macro.

Related to #347  