### PR TITLE
Content update to all cerb cards

### DIFF
--- a/views/benefits/cerb-en.njk
+++ b/views/benefits/cerb-en.njk
@@ -5,25 +5,14 @@
   </h2>
 
   <ul class="list-none list-outside pl-0">
-    {{ blueLI("$2,000 every 4 weeks") }}
-    {{ blueLI("Up to 4 months") }}
+    {{ blueLI("$500 per week") }}
+    {{ blueLI("Up to 16 weeks if you keep  meeting the eligibility criteria") }}
     {{ blueLI("First payment within 10 days of applying") }}
   </ul>
 
   <div class="pb-5 mt-6">
 
-    <strong>The Canada Emergency Response Benefit (CERB) can help if you:</strong>
-    <ul class='list-outside list-disc'>
-      <li>Did not leave your job voluntarily.</li>
-      <li>Earned at least $5,000 in 2019 or the last 12 months.</li>
-      <li>Lost <a href="https://www.canada.ca/en/services/benefits/ei/cerb-application/questions.html#income-requirements" target="_blank">income</a> because of COVID-19: <ul>
-          <li>In the first 4 weeks you apply for, you received no more than $1,000 for at least 14 consecutive days.</li>
-          <li>For the next 4-week periods after your first application, you expect to receive no more than $1,000 for the whole period.</li>
-        </ul>
-      </li>
-    </ul>
-
-    <strong>Next steps:</strong>
+   <strong>Next steps:</strong>
     <ul class='list-outside list-disc'>
       <li>You’ll be asked some questions to direct you to apply through either the Canada Revenue Agency (CRA) or Service Canada.</li>
       <li>The application will ask you to declare that you meet the eligibility criteria, so read the details carefully.</li>
@@ -35,6 +24,6 @@
   {{ infoLink(
         "cerb",
         "https://www.canada.ca/en/services/benefits/ei/cerb-application.html",
-        "Check your eligibility for CERB"
+        "Find out where to apply"
     )}}
 </div>

--- a/views/benefits/cerb-en.njk
+++ b/views/benefits/cerb-en.njk
@@ -6,7 +6,7 @@
 
   <ul class="list-none list-outside pl-0">
     {{ blueLI("$500 per week") }}
-    {{ blueLI("Up to 16 weeks if you keep  meeting the eligibility criteria") }}
+    {{ blueLI("Up to 16 weeks", "if you keep  meeting the eligibility criteria") }}
     {{ blueLI("First payment within 10 days of applying") }}
   </ul>
 

--- a/views/benefits/cerb-fr.njk
+++ b/views/benefits/cerb-fr.njk
@@ -6,7 +6,7 @@
 
   <ul class="list-none list-outside pl-0">
     {{ blueLI("500 $ par semaine") }}
-    {{ blueLI("Jusqu’à 16 semaines tant que vous répondez aux critères d’admissibilité") }}
+    {{ blueLI("Jusqu’à 16 semaines", "tant que vous répondez aux critères d’admissibilité") }}
     {{ blueLI("À recevoir au plus tard 10 jours après la demande") }}
   </ul>
 
@@ -14,7 +14,7 @@
 
     <strong>Prochaines étapes :</strong>
     <ul class='list-outside list-disc'>
-      <li>Vous devrez répondre à quelques questions afin de déterminer si vous devez présenter la demande pour la PCU auprès de l’agence du revenu du Canada (ARC) ou Services Canada.</li>
+      <li>Vous devrez répondre à quelques questions afin de déterminer si vous devez présenter la demande auprès de l’agence du revenu du Canada (ARC) ou Services Canada.</li>
       <li>L’application vous demandera de confirmer que vous répondez aux critères d’admissibilité. Lisez attentivement les détails.</li>
       <li>Ces montants sont imposables.</li>
     </ul>

--- a/views/benefits/cerb-fr.njk
+++ b/views/benefits/cerb-fr.njk
@@ -5,23 +5,12 @@
   </h2>
 
   <ul class="list-none list-outside pl-0">
-    {{ blueLI("2000 $ aux 4 semaines") }}
-    {{ blueLI("Pendant 4 mois maximum") }}
+    {{ blueLI("500 $ par semaine") }}
+    {{ blueLI("Jusqu’à 16 semaines tant que vous répondez aux critères d’admissibilité") }}
     {{ blueLI("À recevoir au plus tard 10 jours après la demande") }}
   </ul>
 
   <div class="pb-5 mt-6">
-
-    <strong>Cette prestation peut vous aider si :</strong>
-    <ul class='list-outside list-disc'>
-      <li>vous avez été forcé de quitter votre emploi.</li>
-      <li>vous avez gagné un revenu d’au moins 5000 $ en 2019 ou dans les 12 derniers mois.</li>
-      <li>vous avez perdu du <a href="https://www.canada.ca/fr/services/prestations/ae/pcusc-application/questions.html#exigences-revenu" target="_blank">revenu</a> en raison de la COVID-19 :<ul>
-          <li>Votre revenu n’était pas plus de 1000 $ pendant au moins 14 jours consécutifs durant les 4 premières semaines de votre demande.</li>
-          <li>Vous anticipez ne recevoir pas plus de 1000 $ durant les prochaines périodes de 4 semaines.</li>
-        </ul>
-      </li>
-    </ul>
 
     <strong>Prochaines étapes :</strong>
     <ul class='list-outside list-disc'>
@@ -35,6 +24,6 @@
   {{ infoLink(
         "cerb",
         "https://www.canada.ca/fr/services/prestations/ae/pcusc-application.html",
-        "Vérifier votre admissibilité à la PCU"
+        "Découvrez comment appliquer"
     )}}
 </div>

--- a/views/benefits/ei_regular_cerb-en.njk
+++ b/views/benefits/ei_regular_cerb-en.njk
@@ -4,7 +4,7 @@
   </h2>
   <ul class="list-none list-outside pl-0">
     {{ blueLI("$500 per week") }}
-    {{ blueLI("Up to 16 weeks if you keep  meeting the eligibility criteria") }}
+    {{ blueLI("Up to 16 weeks", "if you keep  meeting the eligibility criteria") }}
     {{ blueLI("First payment within 10 days of applying") }}
   </ul>
   <div class="pb-5 mt-6">

--- a/views/benefits/ei_regular_cerb-en.njk
+++ b/views/benefits/ei_regular_cerb-en.njk
@@ -3,23 +3,11 @@
     {{__("ei_regular_cerb.header")}}
   </h2>
   <ul class="list-none list-outside pl-0">
-    {{ blueLI("$2,000 every 4 weeks") }}
-    {{ blueLI("Up to 4 months") }}
+    {{ blueLI("$500 per week") }}
+    {{ blueLI("Up to 16 weeks if you keep  meeting the eligibility criteria") }}
     {{ blueLI("First payment within 10 days of applying") }}
   </ul>
   <div class="pb-5 mt-6">
-
-    <strong>The benefit can help if you:</strong>
-    <ul class='list-disc list-outside'>
-      <li> Did not leave your job voluntarily. </li>
-      <li>Earned at least $5,000 in 2019 or the last 12 months.</li>
-      <li>Lost <a href="https://www.canada.ca/en/services/benefits/ei/cerb-application/questions.html#income-requirements" target="_blank">income</a> because of COVID-19:
-        <ul class='list-disc list-outside'>
-          <li>In the first 4 weeks you apply for, you received no more than $1,000 for at least 14 consecutive days.</li>
-          <li>For the next 4-week periods after your first application, you expect to receive no more than $1,000 for the whole period.</li>
-        </ul>
-      </li>
-    </ul>
 
     <strong>Next steps:</strong>
     <ul class='list-disc list-outside'>
@@ -33,6 +21,6 @@
   {{ infoLink(
         "ei_regular_cerb",
         "https://www.canada.ca/en/services/benefits/ei/cerb-application.html",
-        "Check your eligibility for CERB"
+        "Find out where to apply"
     )}}
 </div>

--- a/views/benefits/ei_regular_cerb-fr.njk
+++ b/views/benefits/ei_regular_cerb-fr.njk
@@ -6,7 +6,7 @@
 
   <ul class="list-none list-outside pl-0">
     {{ blueLI("500 $ par semaine") }}
-    {{ blueLI("Jusqu’à 16 semaines tant que vous répondez aux critères d’admissibilité") }}
+    {{ blueLI("Jusqu’à 16 semaines", "tant que vous répondez aux critères d’admissibilité") }}
     {{ blueLI("À recevoir au plus tard 10 jours après la demande") }}
   </ul>
 
@@ -14,7 +14,7 @@
 
     <strong>Prochaines étapes :</strong>
     <ul class='list-outside list-disc'>
-      <li>Vous devrez répondre à quelques questions afin de déterminer si vous devez présenter la demande pour la PCU auprès de l’agence du revenu du Canada (ARC) ou Services Canada.</li>
+      <li>Vous devrez répondre à quelques questions afin de déterminer si vous devez présenter la demande auprès de l’agence du revenu du Canada (ARC) ou Services Canada.</li>
       <li>L’application vous demandera de confirmer que vous répondez aux critères d’admissibilité. Lisez attentivement les détails.</li>
       <li>Ces montants sont imposables.</li>
     </ul>

--- a/views/benefits/ei_regular_cerb-fr.njk
+++ b/views/benefits/ei_regular_cerb-fr.njk
@@ -5,23 +5,12 @@
   </h2>
 
   <ul class="list-none list-outside pl-0">
-    {{ blueLI("2000 $ aux 4 semaines") }}
-    {{ blueLI("Pendant 4 mois maximum") }}
+    {{ blueLI("500 $ par semaine") }}
+    {{ blueLI("Jusqu’à 16 semaines tant que vous répondez aux critères d’admissibilité") }}
     {{ blueLI("À recevoir au plus tard 10 jours après la demande") }}
   </ul>
 
   <div class="pb-5 mt-6">
-
-    <strong>Cette prestation peut vous aider si :</strong>
-    <ul class='list-outside list-disc'>
-      <li>vous avez été forcé de quitter votre emploi.</li>
-      <li>vous avez gagné un revenu d’au moins 5000 $ en 2019 ou dans les 12 derniers mois.</li>
-      <li>vous avez arrêté de travailler en raison de la COVID-19 :<ul>
-          <li>Votre revenu n’était pas plus de 1000 $ pendant au moins 14 jours consécutifs durant les 4 premières semaines de votre demande.</li>
-          <li>Vous anticipez ne recevoir pas plus de 1000 $ durant les prochaines périodes de 4 semaines.</li>
-        </ul>
-      </li>
-    </ul>
 
     <strong>Prochaines étapes :</strong>
     <ul class='list-outside list-disc'>
@@ -35,6 +24,6 @@
   {{ infoLink(
         "ei_regular_cerb",
         "https://www.canada.ca/fr/services/prestations/ae/pcusc-application.html",
-        "Vérifier votre admissibilité à la PCU"
+        "Découvrez comment appliquer"
     )}}
 </div>

--- a/views/benefits/ei_sickness_cerb-en.njk
+++ b/views/benefits/ei_sickness_cerb-en.njk
@@ -6,7 +6,7 @@
 
   <ul class="list-none list-outside pl-0">
     {{ blueLI("$500 per week") }}
-    {{ blueLI("Up to 16 weeks if you keep  meeting the eligibility criteria") }}
+    {{ blueLI("Up to 16 weeks", "if you keep  meeting the eligibility criteria") }}
     {{ blueLI("First payment within 10 days of applying") }}
   </ul>
 

--- a/views/benefits/ei_sickness_cerb-en.njk
+++ b/views/benefits/ei_sickness_cerb-en.njk
@@ -5,23 +5,12 @@
   </h2>
 
   <ul class="list-none list-outside pl-0">
-    {{ blueLI("$2,000  every 4 weeks") }}
-    {{ blueLI("Up to 4 months") }}
+    {{ blueLI("$500 per week") }}
+    {{ blueLI("Up to 16 weeks if you keep  meeting the eligibility criteria") }}
     {{ blueLI("First payment within 10 days of applying") }}
   </ul>
 
   <div class="pb-5 mt-6">
-
-    <strong>The benefit can help if you:</strong>
-    <ul class='list-disc list-outside'>
-      <li> Did not leave your job voluntarily. </li>
-      <li>Earned at least $5,000 in 2019 or the last 12 months.</li>
-      <li>Lost <a href="https://www.canada.ca/en/services/benefits/ei/cerb-application/questions.html#income-requirements" target="_blank">income</a> because of COVID-19: <ul class='list-disc list-outside'>
-          <li>In the first 4 weeks you apply for, you received no more than $1,000 for at least 14 consecutive days.</li>
-          <li>For the next 4-week periods after your first application, you expect to receive no more than $1,000 for the whole period.</li>
-        </ul>
-      </li>
-    </ul>
 
     <strong>Next steps:</strong>
     <ul class='li-disc list-outside'>
@@ -35,6 +24,6 @@
   {{ infoLink(
         "ei_sickness_cerb",
         "https://www.canada.ca/en/services/benefits/ei/cerb-application.html",
-        "Check your eligibility for CERB"
+        "Find out where to apply"
     )}}
 </div>

--- a/views/benefits/ei_sickness_cerb-fr.njk
+++ b/views/benefits/ei_sickness_cerb-fr.njk
@@ -6,7 +6,7 @@
 
   <ul class="list-none list-outside pl-0">
     {{ blueLI("500 $ par semaine") }}
-    {{ blueLI("Jusqu’à 16 semaines tant que vous répondez aux critères d’admissibilité") }}
+    {{ blueLI("Jusqu’à 16 semaines", "tant que vous répondez aux critères d’admissibilité") }}
     {{ blueLI("À recevoir au plus tard 10 jours après la demande") }}
   </ul>
 
@@ -14,7 +14,7 @@
 
     <strong>Prochaines étapes :</strong>
     <ul class='list-outside list-disc'>
-      <li>Vous devrez répondre à quelques questions afin de déterminer si vous devez présenter la demande pour la PCU auprès de l’agence du revenu du Canada (ARC) ou Services Canada.</li>
+      <li>Vous devrez répondre à quelques questions afin de déterminer si vous devez présenter la demande auprès de l’agence du revenu du Canada (ARC) ou Services Canada.</li>
       <li>L’application vous demandera de confirmer que vous répondez aux critères d’admissibilité. Lisez attentivement les détails.</li>
       <li>Ces montants sont imposables.</li>
     </ul>

--- a/views/benefits/ei_sickness_cerb-fr.njk
+++ b/views/benefits/ei_sickness_cerb-fr.njk
@@ -5,23 +5,12 @@
   </h2>
 
   <ul class="list-none list-outside pl-0">
-    {{ blueLI("2000 $ aux 4 semaines") }}
-    {{ blueLI("Pendant 4 mois maximum") }}
+    {{ blueLI("500 $ par semaine") }}
+    {{ blueLI("Jusqu’à 16 semaines tant que vous répondez aux critères d’admissibilité") }}
     {{ blueLI("À recevoir au plus tard 10 jours après la demande") }}
   </ul>
 
   <div class="pb-5 mt-6">
-
-    <strong>Cette prestation peut vous aider si :</strong>
-    <ul class='list-outside list-disc'>
-      <li>vous avez été forcé de quitter votre emploi.</li>
-      <li>vous avez gagné un revenu d’au moins 5000 $ en 2019 ou dans les 12 derniers mois.</li>
-      <li>vous avez arrêté de travailler en raison de la COVID-19 :<ul>
-          <li>Votre revenu n’était pas plus de 1000 $ pendant au moins 14 jours consécutifs durant les 4 premières semaines de votre demande.</li>
-          <li>Vous anticipez ne recevoir pas plus de 1000 $ durant les prochaines périodes de 4 semaines.</li>
-        </ul>
-      </li>
-    </ul>
 
     <strong>Prochaines étapes :</strong>
     <ul class='list-outside list-disc'>
@@ -35,6 +24,6 @@
   {{ infoLink(
         "ei_sickness_cerb",
         "https://www.canada.ca/fr/services/prestations/ae/pcusc-application.html",
-        "Vérifier votre admissibilité à la PCU"
+        "Découvrez comment appliquer"
     )}}
 </div>

--- a/views/macros/benefit-result.njk
+++ b/views/macros/benefit-result.njk
@@ -1,9 +1,9 @@
-{% macro blueLI(text) %}
+{% macro blueLI(strongText, text) %}
   <li>
     <div class="bg-blue-200 p-5 m-1 text-blue-800">
       <p class="relative m-0 pl-8">
         <img src="{{ asset('/img/check-circle.svg') }}" class="w-6 h-6 mt-1 -ml-8 absolute fill-current" alt="">
-        <strong>{{ text | safe }}</strong>
+        <strong>{{ strongText | safe }}</strong> {% if text %}{{ text }}{% endif %}
       </p>
     </div>
   </li>


### PR DESCRIPTION
Changed blueLI to take two params now `strongText` and `text`. I realize we could have one param with the "safe" enabled, but I think writing html in the string might be harder to read? That's an assumption though, and could be wrong!

| English  | French |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/6607541/80976357-5ae7d900-8df1-11ea-925b-0c6918b812b9.png) | ![image](https://user-images.githubusercontent.com/6607541/80976403-6b984f00-8df1-11ea-918a-2a3508616422.png) |