### PR TITLE
Add emphasis to results screen alert for SR

### DIFF
--- a/routes/results/results.njk
+++ b/routes/results/results.njk
@@ -22,7 +22,7 @@
     {% endif %}
 
     {% if not data.lost_job %}
-        <div data-cy="missed-questions">{{ banner('red', '<p>' + __('results.banner') + '</p>') }}</div>
+        <div data-cy="missed-questions">{{ banner('red', '<p><strong class="font-normal">' + __('results.banner') + '</strong></p>') }}</div>
     {% endif %}
 
     {% if benefits.length > 0 %}


### PR DESCRIPTION
Closes #350 

Adds a non-bolded `<strong>` around the alert text so screen readers can detect that it is important.

![image](https://user-images.githubusercontent.com/1187115/80973512-781aa880-8ded-11ea-86ed-c050e2e1799d.png)

Note that visually nothing changes, but the message is now wrapped in a `<strong>` element.