### PR TITLE
Add <strong> to required legends

### DIFF
--- a/views/macros/checkboxes.njk
+++ b/views/macros/checkboxes.njk
@@ -3,11 +3,11 @@
         <fieldset class="fieldset">
             <legend class="fieldset__legend">
             {% if attributes.required %}
-                <span aria-hidden="true" class="required">*</span>
+                <strong aria-hidden="true" class="required font-normal">*</strong>
             {% endif %}
             {{ __(question) }}
             {% if attributes.required %}
-                <span class="required">{{ __("required")}}</span>
+                <strong class="required font-normal">{{ __("required")}}</strong>
             {% endif %}
             </legend>
             {% if attributes.hint %}

--- a/views/macros/input-text.njk
+++ b/views/macros/input-text.njk
@@ -11,11 +11,11 @@
     <div class="{{ 'has-error' if errors and errors[name] }} {{ attributes.divClasses }}">
         <label for="{{ name }}" id="{{ name }}__label">
             {% if attributes.required %}
-                <span aria-hidden="true" class="required">*</span>
+                <strong aria-hidden="true" class="required font-normal">*</strong>
             {% endif %}
             {{ __(label) }}
             {% if attributes.required %}
-                <span class="required">{{ __("required")}}</span>
+                <strong class="required font-normal">{{ __("required")}}</strong>
             {% endif %}
         </label>
         {% if attributes.hint %}

--- a/views/macros/input-textarea.njk
+++ b/views/macros/input-textarea.njk
@@ -11,11 +11,11 @@
     <div class="{{ 'has-error' if errors and errors[name] }} {{ attributes.divClasses }}">
         <label for="{{ name }}" id="{{ name }}__label">
         {% if attributes.required %}
-                <span aria-hidden="true" class="required">*</span>
+                <strong aria-hidden="true" class="required font-normal">*</strong>
         {% endif %}
         {{ __(label) }}
         {% if attributes.required %}
-            <span class="required">{{ __("required")}}</span>
+            <strong class="required font-normal">{{ __("required")}}</strong>
         {% endif %}
         </label>
         {% if attributes.hint %}

--- a/views/macros/radios.njk
+++ b/views/macros/radios.njk
@@ -2,7 +2,7 @@
     <div class="{{ 'has-error' if errors and errors[key] }}">
         <fieldset class="fieldset">
             <legend class="fieldset__legend">
-                {% if attributes.required %}<span aria-hidden="true" class="required">*</span>{% endif %} {{ question }} {% if attributes.required %} <span class="required">{{ __("required")}}</span>{% endif %}
+                {% if attributes.required %}<strong aria-hidden="true" class="required font-normal">*</strong>{% endif %} {{ question }} {% if attributes.required %} <strong class="required font-normal">{{ __("required")}}</strong>{% endif %}
                 {% if errors and errors[key] %}
                     {{ validationMessage(errors[key].msg, key) }}
                 {% endif %}


### PR DESCRIPTION
Closes #349 

Change the `<span>` around `*` and `(required)` on field labels with `<strong>` to indicate the relative importance of the text.

Note that although currently we are only using the radios element, I have gone ahead and made this change to the rest of the form macros.



