### PR TITLE
on focus for green buttons, add outline offset

### DIFF
--- a/assets/scss/components/_buttons.scss
+++ b/assets/scss/components/_buttons.scss
@@ -30,6 +30,7 @@
 
   &:focus {
     @include focus();
+    outline-offset: 5px !important;
   }
 
   &:hover,


### PR DESCRIPTION
to maintain an appropriate contrast ratio

Resolves #354 

![image](https://user-images.githubusercontent.com/6607541/80979138-f890d780-8df4-11ea-8724-8cbfaa70a463.png)
