### PR TITLE
Fix language toggle on Results screen

### DIFF
--- a/app.js
+++ b/app.js
@@ -115,6 +115,18 @@ app.use(function (req, res, next) {
   next()
 })
 
+// Helper middleware used in languageLink.njk
+app.use(function (req, res, next) {
+  const fullUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
+  const url = new URL(fullUrl);
+  const querystring = url.search;
+
+  app.locals.getTranslatedRoute = (route, lang) => {
+    return route.path[lang] + querystring;
+  }
+  next()
+})
+
 // middleware to redirect french paths to the french domain and english paths to the english domain
 /* istanbul ignore next */
 app.use(function (req, res, next) {

--- a/views/_includes/languageLink.njk
+++ b/views/_includes/languageLink.njk
@@ -2,10 +2,10 @@
     <h2 class="sr-only">{{ __("Language Selection") }}</h2>
     <div class="language-link">
         {% if locale != 'fr' %}
-            <a href="{{route.path.fr}}" lang="fr">Français</a>
+            <a href="{{ getTranslatedRoute(route, 'fr') }}" lang="fr">Français</a>
         {% endif %}
         {% if locale != 'en' %}
-            <a href="{{route.path.en}}" lang="en">English</a>
+            <a href="{{ getTranslatedRoute(route, 'en') }}" lang="en">English</a>
         {% endif %}
     </div>
 {% endif %}


### PR DESCRIPTION
Closes #361 

Fixes the language switching bug on the Results screen. When on the results screen, if you switched language, you would lose your results.

Introduced in #338, this bug was due to the language switch link not preserving the querystring parameters required for the results screen to display.

To fix, I added a middleware helper for use in the languageLink.njk template. This helper will accept the current route object, and a selected language. It will return the language-specific route, with the querystring intact.