### PR TITLE
Use TailwindCSS purge option instead of purgecss directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@csstools/postcss-sass": "^4.0.0",
-    "@fullhuman/postcss-purgecss": "^2.1.0",
     "airtable": "^0.8.1",
     "applicationinsights": "^1.7.5",
     "clean-webpack-plugin": "^3.0.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,27 +1,10 @@
 const cssnano = require('cssnano')
-const purgecss = require('@fullhuman/postcss-purgecss')({
-  // Specify the paths to all of the template files in your project
-  content: ['./routes/**/*.njk', './views/**/*.njk'],
-
-  // Include any special characters you're using in this regular expression
-  defaultExtractor: (content) => content.match(/[\w-/:]+(?<!:)/g) || [],
-
-  // whitelist dynamic class names
-  whitelist: [
-    'banner--blue',
-    'banner--blue__icon',
-    'banner--red',
-    'hide--desktop',
-    'hide--mobile',
-  ],
-})
 
 module.exports = {
   plugins: [
     require('@csstools/postcss-sass'),
     require('tailwindcss'),
     require('autoprefixer'),
-    ...(process.env.NODE_ENV === 'production' ? [purgecss] : []),
     cssnano({
       preset: 'default',
     }),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,4 +32,7 @@ module.exports = {
   variants: {},
   plugins: [],
   important: true,
+  purge: {
+    content: ['./routes/**/*.njk', './views/**/*.njk'],
+  },
 }


### PR DESCRIPTION
TailwindCSS 1.4 introduced a new `purge` option which integrates with PurgeCSS to delete unused styles.

Using the Tailwind option rather than PurgeCSS has the the benefit of running only against the Tailwind-generated styles, so no need to maintain a whitelist, and also simplifies our build pipeline.

To test, run the service locally in dev mode and check the Network tab in Chrome and note the size of styles.css. Purge doesn't run in dev mode, so you should see something around 1.9Mb.

Next run the service in production mode (`npm run start`) and check the size of styles.css - should be greatly reduced, somewhere around 21Kb.