### PR TITLE
Feedback storage changes

### DIFF
--- a/routes/feedback/feedback.controller.js
+++ b/routes/feedback/feedback.controller.js
@@ -3,13 +3,21 @@ module.exports = (app, route) => {
   route.draw(app)
     .post((req, res) => {
       const date = new Date();
+      const problems = req.body.problems || [];
+      const url = new URL(req.headers.referer);
 
       const feedback = {
-        'problems': req.body.problems ? req.body.problems.toString() : 'n/a',
+        'incorrect_info': +problems.includes('incorrect_info'),
+        'confusing_info': +problems.includes('confusing_info'),
+        'didnt_find': +problems.includes('didnt_find'),
+        'a11y_issue': +problems.includes('a11y_issue'),
+        'privacy_concerns': +problems.includes('privacy_concerns'),
+        'other_issue': +problems.includes('other_issue'),
         'details': req.body.details || 'n/a',
         'session': req.locals.session.id || 'n/a',
         'version': process.env.GITHUB_SHA || 'n/a',
         'url': req.headers.referer || req.headers.referrer || 'n/a',
+        'path': url.pathname,
         'date': date.toISOString(),
         'language': res.locals.getLocale(),
       }


### PR DESCRIPTION
Closes #389 

This code change supports corresponding Airtable data model changes:

Breaks the 'problems' column up into a single binary column per option. ie from this:
![image](https://user-images.githubusercontent.com/1187115/81303624-f07da580-9049-11ea-8b2f-9cba11e8fcec.png)

to this:
![image](https://user-images.githubusercontent.com/1187115/81303715-0f7c3780-904a-11ea-9738-9dffacc79e8d.png)

Also separates the Path from the URL and stores it separately:
![image](https://user-images.githubusercontent.com/1187115/81303778-27ec5200-904a-11ea-8338-c02a677be67e.png)
