### PR TITLE
correct data on one no-income option

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -122,7 +122,7 @@
   "your_situation.no_income.4": "You’re sick or in mandatory quarantine and on unpaid leave.",
   "your_situation.no_income.5": "You were on parental leave recently, but you cannot return to work due to COVID-19.",
   "your_situation.no_income.6": "You were a college or university student during the 2019-20 school year and now cannot find work.",
-  "your_situation.no_income.7": "You were on Employment Insurance Regular or Fishing Benefits and your claim ended on or after December&nbsp;29,&nbsp;2020.",
+  "your_situation.no_income.7": "You were on Employment Insurance Regular or Fishing Benefits and your claim ended on or after December&nbsp;29,&nbsp;2019.",
   "your_situation.some_income.1": "Your employer has reduced your hours due to COVID-19.",
   "your_situation.some_income.2": "You’ve lost one or two part-time jobs and still have some income.",
   "your_situation.some_income.3": "You’re self-employed and lost some income but you still have some paid work.",


### PR DESCRIPTION
For one of the no income options, one date needed to be corrected from 2020 to 2019

Resolves #416

![image](https://user-images.githubusercontent.com/6607541/81565146-e7047e00-9366-11ea-9412-8e216599dfad.png)
 