### PR TITLE
Feature/finalize analytics

### DIFF
--- a/config/csp.config.js
+++ b/config/csp.config.js
@@ -10,6 +10,7 @@ const scriptSrc = [
   'assets.adobedtm.com',
   "'unsafe-inline'",
   'cv19-benefits-cdn.azureedge.net',
+  'sitecatalyst.omniture.com',
 ]
 
 let upgradeInsecureRequests = true

--- a/routes/start/start.njk
+++ b/routes/start/start.njk
@@ -17,7 +17,7 @@
     </div>
 
     <div class="start-button">
-        <a class="font-semibold button-link py-6 px-5 border shadow" data-cy="start" href="{{ routePath(route.next) }}" role="button" draggable="false">
+        <a class="font-semibold button-link py-6 px-5 border shadow" data-gc-analytics-customclick="ESDC|EDSC:Covid19 Benefits:Start button click" data-cy="start" href="{{ routePath(route.next) }}" role="button" draggable="false">
             {{ __('start.submit') }}
         </a>
     </div>

--- a/views/_includes/adobe.njk
+++ b/views/_includes/adobe.njk
@@ -1,5 +1,5 @@
 <!-- Adobe Analytic tags -->
-<meta name="dcterms.title" content="{{ __('app.title') }}"/>
+<meta name="dcterms.title" content="{% if(title) %}{{ title }} — {% endif %}{{ __('app.title') }}" />
 <meta name="dcterms.language" content="{{ 'eng' if getLocale() === 'en' else 'fra' }}"/>
 <meta name="dcterms.creator" content="CDS"/>
 <meta name="dcterms.accessRights" content="2"/>

--- a/views/macros/benefit-result.njk
+++ b/views/macros/benefit-result.njk
@@ -11,7 +11,7 @@
 
 {% macro infoLink(id, url, text) %}
   <a href="{{ url }}"
-    data-gc-analytics-customclick="ESDC|EDSC:{{id}}:true"
+    data-gc-analytics-customclick="ESDC|EDSC:Covid19 Benefits:{{id}} button click"
     target="_blank"
     class="full-width font-semibold button-link py-6 px-5 border shadow">
     {{ text }}

--- a/views/macros/buttons.njk
+++ b/views/macros/buttons.njk
@@ -3,7 +3,7 @@
         <div class="buttons--left next-button">
             <button class="py-3 px-4 border shadow" data-cy="next" type="submit">{{ __(submitButtonText) }}</button>
         </div>
-        <div class="buttons--right"><a data-gc-analytics-customclick="ESDC|EDSC:startover:true" class="py-3 px-4 button-link transparent full-width" href="{{ cancelUrl }}"><img src="{{ asset('/img/times-circle.svg') }}" class="h-6 w-6" alt="" /><span>{{ __('start_over') }}</span></a></div>
+        <div class="buttons--right"><a data-gc-analytics-customclick="ESDC|EDSC:Covid19 Benefits:Start Over button click" class="py-3 px-4 button-link transparent full-width" href="{{ cancelUrl }}"><img src="{{ asset('/img/times-circle.svg') }}" class="h-6 w-6" alt="" /><span>{{ __('start_over') }}</span></a></div>
     </div>
 {% endmacro %}
 

--- a/views/macros/form.njk
+++ b/views/macros/form.njk
@@ -1,9 +1,9 @@
 {% macro form(label, divClasses, attributes) %}
-    <form method="post" 
-        novalidate
-        data-gc-analytics-formname="ESDC|EDSC:cp19-benefits"
-        data-gc-analytics-collect='[ {"value":"input,select","emptyField": "N/A"}]'
+  <form method="post"
+    novalidate
+    data-gc-analytics-formname="ESDC|EDSC:cp19-benefits"
+    data-gc-analytics-collect='[ {"value":"input[type=radio]","emptyField": "N/A"}]'
     >
-        {{ caller() }}
-    </form>
+    {{ caller() }}
+  </form>
 {% endmacro %}


### PR DESCRIPTION
The Adobe Analytics team at Principle Publisher has requested some changes to the site in order to capture some items as well as make it easier to parse the incoming analytics.

- Make dcterms.title same as page title
- Updating button clicks as per Adobe Analytics team suggestions
- Add sitecatalyst.omniture.com to CSP for script-src
- Change form attributes as per Adobe Analytics team suggestions