### PR TITLE
Use non-time-based default cookie name

### DIFF
--- a/config/cookieSession.config.js
+++ b/config/cookieSession.config.js
@@ -8,8 +8,8 @@
 */
 const oneHour = 1000 * 60 * 60
 const sessionName = `ctb-${
-  process.env.COOKIE_SECRET || Math.floor(new Date().getTime() / oneHour)
-}`
+  process.env.COOKIE_SECRET || 'session'
+  }`
 
 const cookieSessionConfig = {
   name: sessionName,


### PR DESCRIPTION
Don't default to using a time-based name for the cookie, as that can cause problems in multi-server environment. And defaults matter.