### PR TITLE
Fix french feedback-thanks route path

### DIFF
--- a/config/routes.config.js
+++ b/config/routes.config.js
@@ -28,7 +28,7 @@ const routes = [
 
   // feedback
   { name: 'feedback', path: { en: '/feedback', fr: '/feedback' } },
-  { name: 'feedback-thanks', path: { en: '/thanks', fr: 'merci' } },
+  { name: 'feedback-thanks', path: { en: '/thanks', fr: '/merci' } },
 ]
 
 const locales = ['en', 'fr']


### PR DESCRIPTION
Tiny fix, noticed in logs that the feedback-thanks page path was `/frmerci` rather than `/fr/merci`