### PR TITLE
Changes for issue #450

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -111,6 +111,9 @@
   "rrif.header": "Lower mandatory withdrawals for your Registered Retirement Income Fund (RRIF)",
   "rrif.title": "RRIF",
   "some_income.title": "Your situation",
+  "start.business": "Own a business?",
+  "start.businesslink.text": "Find support for your business.",
+  "start.businesslink.url": "https://innovation.ised-isde.canada.ca/s/?language=en",
   "start.intro.2": "Answer some questions to find which federal programs can help you. We cannot guarantee your eligibility, but we can point you to the program details.",
   "start.intro.3": "<strong>New measures are still being announced</strong>, and we’re working to include them as quickly as possible.",
   "start.lastupdated": "Last updated",
@@ -140,8 +143,5 @@
   "your_situation.unchanged_income.2": "You’re on paid leave.",
   "your_situation.unchanged_income.3": "You’re retired.",
   "your_situation.unchanged_income.4": "You were a college or university student during the 2019-20 school year and now cannot find work.",
-  "your_situation.unchanged_income.5": "You’re graduating high school in the 2019-20 school year and have applied for post-secondary education that will start before February 1, 2021.",
-  "start.business": "Own a business?",
-  "start.businesslink.url": "https://innovation.ised-isde.canada.ca/s/?language=en",
-  "start.businesslink.text": "Find support for your business."
+  "your_situation.unchanged_income.5": "You’re graduating high school in the 2019-20 school year and have applied for post-secondary education that will start before February 1, 2021."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -111,12 +111,10 @@
   "rrif.header": "Lower mandatory withdrawals for your Registered Retirement Income Fund (RRIF)",
   "rrif.title": "RRIF",
   "some_income.title": "Your situation",
-  "start.details.p.1": "If you’re a Canadian abroad and need help to pay for your trip home, you can get <a href='https://travel.gc.ca/assistance/emergency-info/financial-assistance/covid-19-financial-help' target='_blank'>an emergency loan</a>.",
-  "start.details.summary": "Are you a Canadian stuck abroad?",
   "start.intro.2": "Answer some questions to find which federal programs can help you. We cannot guarantee your eligibility, but we can point you to the program details.",
   "start.intro.3": "<strong>New measures are still being announced</strong>, and we’re working to include them as quickly as possible.",
   "start.lastupdated": "Last updated",
-  "start.submit": "Start now",
+  "start.submit": "Find help",
   "start.title": "Find financial help during COVID-19",
   "start_over": "Start over",
   "student_debt.1": "Yes.",
@@ -142,5 +140,8 @@
   "your_situation.unchanged_income.2": "You’re on paid leave.",
   "your_situation.unchanged_income.3": "You’re retired.",
   "your_situation.unchanged_income.4": "You were a college or university student during the 2019-20 school year and now cannot find work.",
-  "your_situation.unchanged_income.5": "You’re graduating high school in the 2019-20 school year and have applied for post-secondary education that will start before February 1, 2021."
+  "your_situation.unchanged_income.5": "You’re graduating high school in the 2019-20 school year and have applied for post-secondary education that will start before February 1, 2021.",
+  "start.business": "Own a business?",
+  "start.businesslink.url": "https://innovation.ised-isde.canada.ca/s/?language=en",
+  "start.businesslink.text": "Find support for your business."
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -111,12 +111,10 @@
   "rrif.header": "Diminution du montant de retrait obligatoire de votre fond enregistré de revenu de retraite (FERR)",
   "rrif.title": "FERR",
   "some_income.title": "Votre situation",
-  "start.details.p.1": "Si vous êtes un Canadien actuellement à l’étranger et que vous avez besoin d’aide financière pour revenir au Canada, vous pouvez demander <a href='https://voyage.gc.ca/assistance/info-d-urgence/assistance-financiere/covid-19-aide-financiere' target='_blank'>un prêt d’urgence</a>.",
-  "start.details.summary": "Êtes vous un Canadien actuellement à l’étranger?",
-  "start.intro.2": "Répondez à quelques questions pour trouver quels programmes d’aide financière fédéraux s’offrent à vous. Nous ne pouvons garantir vorte admissibilité, mais nous pouvons vous aider à mieux comprendre leurs particularités.",
+  "start.intro.2": "Répondez à quelques questions pour trouver quels programmes d’aide financière fédéraux s’offrent à vous. Nous ne pouvons garantir votre admissibilité, mais nous pouvons vous aider à mieux comprendre leurs particularités.",
   "start.intro.3": "<strong>De nouvelles prestations sont constamment créées</strong> et nous travaillons à les inclure aussitôt que possible.",
   "start.lastupdated": "Dernière mise à jour le",
-  "start.submit": "Commencer",
+  "start.submit": "Trouver de l’aide",
   "start.title": "Trouver de l’aide financière pendant la COVID-19",
   "start_over": "Recommencer",
   "student_debt.1": "Oui.",
@@ -142,5 +140,8 @@
   "your_situation.unchanged_income.2": "Vous êtes en congé payé.",
   "your_situation.unchanged_income.3": "Vous êtes retraité.",
   "your_situation.unchanged_income.4": "Vous étiez étudiant dans une institution postsecondaire lors de l’année scolaire 2019-20 et ne pouvez trouver un emploi.",
-  "your_situation.unchanged_income.5": "Vous obtiendrez un diplôme d’études secondaires pour l’année scolaire 2019-2020 et avez appliqué pour un programme d’études postsecondaires débutant avant le 1er février 2021."
+  "your_situation.unchanged_income.5": "Vous obtiendrez un diplôme d’études secondaires pour l’année scolaire 2019-2020 et avez appliqué pour un programme d’études postsecondaires débutant avant le 1er février 2021.",
+  "start.business": "Vous êtes propriétaire d’entreprise?",
+  "start.businesslink.url": "https://innovation.ised-isde.canada.ca/s/?language=fr",
+  "start.businesslink.text": "Trouvez du soutien pour votre entreprise."
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -111,6 +111,9 @@
   "rrif.header": "Diminution du montant de retrait obligatoire de votre fond enregistré de revenu de retraite (FERR)",
   "rrif.title": "FERR",
   "some_income.title": "Votre situation",
+  "start.business": "Vous êtes propriétaire d’entreprise?",
+  "start.businesslink.text": "Trouvez du soutien pour votre entreprise.",
+  "start.businesslink.url": "https://innovation.ised-isde.canada.ca/s/?language=fr",
   "start.intro.2": "Répondez à quelques questions pour trouver quels programmes d’aide financière fédéraux s’offrent à vous. Nous ne pouvons garantir votre admissibilité, mais nous pouvons vous aider à mieux comprendre leurs particularités.",
   "start.intro.3": "<strong>De nouvelles prestations sont constamment créées</strong> et nous travaillons à les inclure aussitôt que possible.",
   "start.lastupdated": "Dernière mise à jour le",
@@ -140,8 +143,5 @@
   "your_situation.unchanged_income.2": "Vous êtes en congé payé.",
   "your_situation.unchanged_income.3": "Vous êtes retraité.",
   "your_situation.unchanged_income.4": "Vous étiez étudiant dans une institution postsecondaire lors de l’année scolaire 2019-20 et ne pouvez trouver un emploi.",
-  "your_situation.unchanged_income.5": "Vous obtiendrez un diplôme d’études secondaires pour l’année scolaire 2019-2020 et avez appliqué pour un programme d’études postsecondaires débutant avant le 1er février 2021.",
-  "start.business": "Vous êtes propriétaire d’entreprise?",
-  "start.businesslink.url": "https://innovation.ised-isde.canada.ca/s/?language=fr",
-  "start.businesslink.text": "Trouvez du soutien pour votre entreprise."
+  "your_situation.unchanged_income.5": "Vous obtiendrez un diplôme d’études secondaires pour l’année scolaire 2019-2020 et avez appliqué pour un programme d’études postsecondaires débutant avant le 1er février 2021."
 }

--- a/routes/start/start.njk
+++ b/routes/start/start.njk
@@ -9,17 +9,20 @@
         <p>{{ __('start.intro.3') | safe }}</p>
     </div>
 
-    <div>
-        <details>
-            <summary><span>{{ __('start.details.summary') | safe }}</span></summary>
-            <p>{{ __('start.details.p.1') | safe }}</p>
-        </details>
-    </div>
 
     <div class="start-button">
         <a class="font-semibold button-link py-6 px-5 border shadow" data-gc-analytics-customclick="ESDC|EDSC:Covid19 Benefits:Start button click" data-cy="start" href="{{ routePath(route.next) }}" role="button" draggable="false">
             {{ __('start.submit') }}
         </a>
     </div>
+
+    <div>
+    <p>
+      {{ __('start.business') }}
+      <a href="{{ __('start.businesslink.url') }}"
+        target="_blank"
+        data-gc-analytics-customclick="ESDC|EDSC:Covid19 Benefits:businessHelp button click"
+        >{{__('start.businesslink.text')}}</a>
+    </p>
 
 {% endblock %}


### PR DESCRIPTION
- Removes Canadians Abroad text summary/details and text from local files
- Changes start over button text
- Add a link to the business benefits
- Fixes French typo

New French Screen:
![image](https://user-images.githubusercontent.com/87738/82090745-2236e200-96c4-11ea-80f8-38e8eb74fda0.png)

New English Screen: 
![image](https://user-images.githubusercontent.com/87738/82090788-3844a280-96c4-11ea-9879-9f9f6142b496.png)

Resolves #450