### PR TITLE
Fix/meta url

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,6 +108,7 @@ app.use((req, res) => {
     const cdnprefix = process.env.CDN_PREFIX || '';
   
     if (process.env.NODE_ENV === 'production') {
+      // this because the cdn prefix already has a double slash in the url (ex. //cv19-benefits-cdn.azureedge.net/img/arrow-circle-left.svg)
       return req.protocol + ':' + cdnprefix + path;
     }
     return req.protocol + '://' + req.get('host') + path;

--- a/app.js
+++ b/app.js
@@ -99,21 +99,17 @@ app.locals.hasData = hasData
 
 /**
  * Create an asset path helper for templates
- * If a CDN_PREFIX is set in env, and mode is production,
- * the helper will return the path with the CDN prefix,
- * otherwise it just returns the path
+ * If a CDN_PREFIX is set in env, the helper 
+ * will return the path with the CDN prefix,
+ * otherwise it just returns the path with 
+ * current protocol and host prefix
  */
 app.use((req, res, next) => {
   app.locals.asset = (path) => {
-    const cdnprefix = process.env.CDN_PREFIX || '';
-  
-    if (process.env.NODE_ENV === 'production') {
-      // this because the cdn prefix already has a double slash in the url (ex. //cv19-benefits-cdn.azureedge.net/img/arrow-circle-left.svg)
-      return req.protocol + ':' + cdnprefix + path;
-    }
-    return req.protocol + '://' + req.get('host') + path;
-  }
+    const assetPrefix = process.env.CDN_PREFIX || '//' + req.get('host');
 
+    return req.protocol + ':' + assetPrefix + path;
+  }
   next()
 })
 

--- a/app.js
+++ b/app.js
@@ -113,7 +113,6 @@ app.locals.asset = (path) => {
 }
 
 app.use((req, res, next) => {
-  app.locals.siteUrl = req.protocol + '://' + req.get('host')
   app.locals.pageUrl = req.protocol + '://' + req.get('host') + req.originalUrl
   next()
 })

--- a/app.js
+++ b/app.js
@@ -103,7 +103,7 @@ app.locals.hasData = hasData
  * the helper will return the path with the CDN prefix,
  * otherwise it just returns the path
  */
-app.use((req, res) => {
+app.use((req, res, next) => {
   app.locals.asset = (path) => {
     const cdnprefix = process.env.CDN_PREFIX || '';
   
@@ -113,6 +113,8 @@ app.use((req, res) => {
     }
     return req.protocol + '://' + req.get('host') + path;
   }
+
+  next()
 })
 
 app.use((req, res, next) => {

--- a/app.js
+++ b/app.js
@@ -103,14 +103,16 @@ app.locals.hasData = hasData
  * the helper will return the path with the CDN prefix,
  * otherwise it just returns the path
  */
-app.locals.asset = (path) => {
-  const cdnprefix = process.env.CDN_PREFIX || '';
-
-  if (process.env.NODE_ENV === 'production') {
-    return cdnprefix + path;
+app.use((req, res) => {
+  app.locals.asset = (path) => {
+    const cdnprefix = process.env.CDN_PREFIX || '';
+  
+    if (process.env.NODE_ENV === 'production') {
+      return req.protocol + ':' + cdnprefix + path;
+    }
+    return path;
   }
-  return path;
-}
+})
 
 app.use((req, res, next) => {
   app.locals.pageUrl = req.protocol + '://' + req.get('host') + req.originalUrl

--- a/app.js
+++ b/app.js
@@ -110,7 +110,7 @@ app.use((req, res) => {
     if (process.env.NODE_ENV === 'production') {
       return req.protocol + ':' + cdnprefix + path;
     }
-    return path;
+    return req.protocol + '://' + req.get('host') + path;
   }
 })
 

--- a/views/_includes/meta.njk
+++ b/views/_includes/meta.njk
@@ -19,7 +19,7 @@
 <meta property="og:url" content="{{ pageUrl }}">
 <meta property="og:title" content="{{ metaTitle }}">
 <meta property="og:description" content="{{ __('app.description') }}">
-<meta property="og:image" content="{{siteUrl}}{{ metaImage }}">
+<meta property="og:image" content="{{ metaImage }}">
 <meta property="og:image:width" content="746" />
 <meta property="og:image:height" content="617" />
 <meta property="og:image:alt" content="{{ __('app.metaImageAlt') }}">
@@ -29,5 +29,5 @@
 <meta property="twitter:url" content="{{ pageUrl }}">
 <meta property="twitter:title" content="{{ metaTitle }}">
 <meta property="twitter:description" content="{{ __('app.description') }}">
-<meta property="twitter:image" content="{{siteUrl}}{{ metaImage }}">
+<meta property="twitter:image" content="{{ metaImage }}">
 <meta property="twitter:image:alt" content="{{ __('app.metaImageAlt') }}">


### PR DESCRIPTION
add req.protocol for asset() helper calls to CDN

and just always serve an absolute url for assets (to make sure the meta image urls work testing on heroku apps as well)

without the absolute url it was messing with the social share cards, as it would return `//cv19-benefits-cdn.azureedge.net/img/arrow-circle-left.svg`, and the cards need the full `https://cv19-benefits-cdn.azureedge.net/img/arrow-circle-left.svg` for sharing.

Hopefully it works, can't know without testing on dev!