### PR TITLE
Enable trust proxies

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,6 +45,10 @@ if (!locales) locales = ['en', 'fr']
 // initialize application.
 const app = express()
 
+// Get req.protocol from X-Forwarded-Proto
+// see: https://docs.microsoft.com/en-us/azure/app-service/containers/configure-language-nodejs#detect-https-session
+app.set('trust proxy', 1)
+
 // general app configuration.
 app.use(express.json())
 app.use(express.urlencoded({ extended: false }))


### PR DESCRIPTION
Our service runs behind an AppService proxy which handles SSL termination, so requests always reach our service as http. This causes our asset helper to receive the wrong protocol from `req.protocol`. This tells node to get that information from the X-Forwarded-Proto header instead.

To test, check the heroku review environment. View source and check the URLs for assets (img,js,css) that use the asset helper. Previously, they were always rendering `http` protocol, now they should all be rendering with `https` protocol.