### PR TITLE
Don't clear all session data on start / start over

### DIFF
--- a/routes/global/global.controller.js
+++ b/routes/global/global.controller.js
@@ -8,11 +8,11 @@ module.exports = (app, table) => {
   })
 
   app.get('/clear', (req, res) => {
-    req.session = null
+    req.session.formdata = null
     res.redirect(302, '/')
   })
 
-  app.use(function(req, res, next) {
+  app.use(function (req, res, next) {
     res.status(404)
 
     let message = false
@@ -28,7 +28,7 @@ module.exports = (app, table) => {
     res.render('404', { message })
   })
 
-  app.use(function(err, req, res, next) {
+  app.use(function (err, req, res, next) {
     res.status(500)
 
     console.error(`☠️ Error => ${err.message}`)

--- a/routes/start/start.controller.js
+++ b/routes/start/start.controller.js
@@ -20,7 +20,7 @@ module.exports = (app, route) => {
   app.get('/fr', (req, res) => res.redirect(route.path.fr))
 
   route.draw(app).get(async (req, res) => {
-    req.session = null
+    req.session.formdata = null
     res.render(name, routeUtils.getViewData(req, {
       hideBackButton: true,
       title: res.__('start.title'),


### PR DESCRIPTION
Closes #473 

This change will clear only the collected form data when visiting `/clear` or `/en/start`, rather than the whole session.

Previously, we would do this on those routes:

```
req.session = null
```

This had the effect of clearing the entire session. But what we really need is to just clear the formdata so that the user can start fresh. If we preserve the rest of the session (which also contains the session id), then we can track users as they complete different flows (ie, they go through the service once, start over, and go through it again).

The above code has been changed to this:

```
req.session.formdata = null
```

This was raised as part of Researchers desire to understand if a user is submitting feedback from the start page, it would be helpful to know if they only visited the start page, or if they had already gone through the service once and didn't find what they needed.

This is a tough one to test, but here's the log output of the effect:

![image](https://user-images.githubusercontent.com/1187115/82584999-4cc0e900-9b63-11ea-80e4-f58d5c14d48b.png)

The highlighted rows are when a user clicks "Start Over" - note that their session id is maintained as they return to the beginning of the process.