### PR TITLE
Adding fetch depth as per docs

### DIFF
--- a/.github/workflows/build-deploy-dev.yml
+++ b/.github/workflows/build-deploy-dev.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: 'Checkout Github Action'
         uses: actions/checkout@master
+        with: 
+          fetch-depth: '0'
 
       - name: tag_code
         id: tag


### PR DESCRIPTION
Hopefully this should fix the issue with the auto tagger always tagging a patch version

As per the action documentation https://github.com/anothrNick/github-tag-action