### PR TITLE
Adds French Text to Results page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this product will be documented in this file.
 
 ## 2020-06-01
 
+### Fixed:
+* Added French text for Non-Matching Results Header on Results Page
+
 ### Changed: 
 * Modified content on start page
 * Modified content on results page

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -139,14 +139,14 @@
   "results.less_info": "Moin d'infos",
   "results.more_info": "Plus d'infos",
   "results.no_results.preamble": "Aucune des prestations actuellement disponibles ne s’applique à votre situation. Nous ajoutons régulièrement de nouvelles prestations. Revenez consulter cet outil plus tard ou si votre situation change.",
-  "results.not_for_you": "Not for you",
+  "results.not_for_you": "Ne s’appliquent pas à vous",
   "results.other_potential_help": "Aide supplémentaire disponible",
   "results.other_potential_help.preamble": "L’aide suivante est également disponible :",
   "results.results": "résultats",
   "results.situation_changes": false,
-  "results.unavailable_benefits_preamble": "Based on what you told us, the following options do not fit your situation.",
-  "results.unavailable_close_link": "Close list of benefits not relevant for you",
-  "results.unavailable_view_link": "Open list of benefits not relevant for you",
+  "results.unavailable_benefits_preamble": "Selon les réponses que vous nous avez fournies, les prestations suivantes ne s’appliquent pas à votre situation.",
+  "results.unavailable_close_link": "Fermer la liste des prestations qui ne s'appliquent pas à vous",
+  "results.unavailable_view_link": "Voir la liste des prestations qui ne s’appliquent pas à vous.",
   "results_title": {
     "one": "Résultats",
     "other": "%s résultats"


### PR DESCRIPTION
# Description
Fixes #512 

Adds French text to results page for No Results Section 

Text for Close Link was missing from Figma so I translated myself.

## Test Instructions

Navigate to Results Page.
Ensure that All text on French page is French and Makes sense

## Help Requested

Text on Results Page