### PR TITLE
Add attributes to track not relevant list expansion clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this product will be documented in this file.
 
+## 2020-06-04
+
+### Added 
+* Tracking when users click on the button to view the not-relevant benefits.
+
 ## 2020-06-02
 
 ### Added:

--- a/routes/results/results.njk
+++ b/routes/results/results.njk
@@ -82,7 +82,7 @@
 
             <p class="font-light px-4">{{ __('results.unavailable_benefits_preamble') }}</p>
 
-            <button id="unavailableBenefitsButton" aria-controls="unavailableBenefitsList" aria-expanded="false" class="px-4 text-red-700 hidden">
+            <button id="unavailableBenefitsButton" data-gc-analytics-customclick="ESDC|EDSC:Covid19 Benefits:List of benefits not relevant click" aria-controls="unavailableBenefitsList" aria-expanded="false" class="px-4 text-red-700 hidden">
                 <div class="closed">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="w-6 h-6 fill-current inline">
                         <path d="M16 10c0 .553-.048 1-.601 1H11v4.399c0 .552-.447.601-1 .601-.553 0-1-.049-1-.601V11H4.601C4.049 11 4 10.553 4 10c0-.553.049-1 .601-1H9V4.601C9 4.048 9.447 4 10 4c.553 0 1 .048 1 .601V9h4.399c.553 0 .601.447.601 1z" />


### PR DESCRIPTION
# Description

This closes the following task: https://trello.com/c/AfFtDmcn/182-add-attributes-to-track-not-relevant-list-expansion-clicks

I simply copied the attribute over from the trello card verbatim.

## Test Instructions

1. Navigate to the results page.
1. Inspect the button "Open list of Benefits not relevant for you" (See Image Below)
![image](https://user-images.githubusercontent.com/87738/83792334-eced3680-a668-11ea-85b8-f9832b5a7c7e.png)
1. Validate that the following attribute is on the button: `data-gc-analytics-customclick="ESDC|EDSC:Covid19 Benefits:List of benefits not relevant click"`
*Please Note:* We will need to validate this with Analytics team at ESDC after it's in production.
