### PR TITLE
Add featureFlag for Enabling DTC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ AIRTABLE_BASE_ID=
 
 # Required for CDN integration
 CDN_PREFIX=
+
+# Feature Flags
+FF_ENABLE_DTC=

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Run Cypress end-to-end
       uses: cypress-io/github-action@v1
       env:
+        FF_ENABLE_DTC: true
         NODE_ENV: test
         A11Y_TRACKER_KEY: ${{ secrets.A11Y_TRACKER_KEY }}
         CI: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this product will be documented in this file.
 
 ### Added
 * The Disability Tax Credit
+* Feature flag for DTC
 ### Bugfix: 
 * Fixing HTML Validation Errors
 

--- a/app.js
+++ b/app.js
@@ -36,6 +36,7 @@ const {
   csrfToken,
   assetPath,
   assetVersion,
+  featureFlags,
 } = require('./middleware')
 
 // check to see if we have a custom configRoutes function
@@ -124,7 +125,7 @@ app.use(languageLinkHelper(app))
 // middleware to redirect french paths to the french domain and english paths to the english domain
 app.use(domainRedirector)
 app.use(logger)
-
+app.use(featureFlags)
 app.routes = configRoutes(app, routes, locales)
 
 // view engine setup

--- a/cypress/integration/bugs.spec.js
+++ b/cypress/integration/bugs.spec.js
@@ -1,6 +1,10 @@
 /* eslint-disable no-undef */
 describe('Found Bugs', () => {
   describe('Issue #378 - Bug showing CERB twice when going back and forth', () => {
+    beforeEach(() => {
+      process.env.FF_ENABLE_DTC = true
+      process.env.COOKIE_SECRET = 'found_bugs'
+    })
     it('Check some-income lost-a-job to no-income', () => {
       cy.visit('/')
       cy.get('[data-cy=start]').click()

--- a/cypress/integration/bugs.spec.js
+++ b/cypress/integration/bugs.spec.js
@@ -2,7 +2,6 @@
 describe('Found Bugs', () => {
   describe('Issue #378 - Bug showing CERB twice when going back and forth', () => {
     beforeEach(() => {
-      process.env.FF_ENABLE_DTC = true
       process.env.COOKIE_SECRET = 'found_bugs'
     })
     it('Check some-income lost-a-job to no-income', () => {

--- a/cypress/integration/errors.spec.js
+++ b/cypress/integration/errors.spec.js
@@ -15,7 +15,6 @@ describe('Error Pages', () => {
   ['en', 'fr'].forEach((lang) => {
     describe('Language: ' + lang, () => {
       beforeEach(() => {
-        process.env.FF_ENABLE_DTC = true
         process.env.COOKIE_SECRET = 'error_pages'
       })
 

--- a/cypress/integration/errors.spec.js
+++ b/cypress/integration/errors.spec.js
@@ -1,9 +1,9 @@
-
-const route = (name, lang) => require('../../utils/route.helpers').simpleRoute(name, lang, true);
+const route = (name, lang) =>
+  require('../../utils/route.helpers').simpleRoute(name, lang, true)
 /* eslint-disable no-undef */
 function testError(name, lang, numberOfExpectedErrors) {
   const numErrors = numberOfExpectedErrors || 1
-  const path = route(name, lang);
+  const path = route(name, lang)
 
   cy.visit(path)
   cy.get('[data-cy=next]').click()
@@ -14,6 +14,10 @@ function testError(name, lang, numberOfExpectedErrors) {
 describe('Error Pages', () => {
   ['en', 'fr'].forEach((lang) => {
     describe('Language: ' + lang, () => {
+      beforeEach(() => {
+        process.env.FF_ENABLE_DTC = true
+      })
+
       it('Province', () => {
         testError('question-province', lang)
       })

--- a/cypress/integration/errors.spec.js
+++ b/cypress/integration/errors.spec.js
@@ -16,6 +16,7 @@ describe('Error Pages', () => {
     describe('Language: ' + lang, () => {
       beforeEach(() => {
         process.env.FF_ENABLE_DTC = true
+        process.env.COOKIE_SECRET = 'error_pages'
       })
 
       it('Province', () => {

--- a/cypress/integration/results.spec.js
+++ b/cypress/integration/results.spec.js
@@ -6,7 +6,6 @@ describe('Result Page Only tests', () => {
     describe('Language: ' + lang, () => {
 
       beforeEach(() => {
-        process.env.FF_ENABLE_DTC = true
         process.env.COOKIE_SECRET = 'result'
       })
 
@@ -30,7 +29,6 @@ describe('Paths and Benefits', () => {
     describe('Language: ' + lang, () => {
 
       beforeEach(() => {
-        process.env.FF_ENABLE_DTC = true
         process.env.COOKIE_SECRET = 'paths'
         cy.visit('/' + lang)
         cy.reportA11y()

--- a/cypress/integration/results.spec.js
+++ b/cypress/integration/results.spec.js
@@ -4,6 +4,11 @@ const route = (name, lang) => require('../../utils/route.helpers').simpleRoute(n
 describe('Result Page Only tests', () => {
   ['en', 'fr'].forEach((lang) => {
     describe('Language: ' + lang, () => {
+
+      beforeEach(() => {
+        process.env.FF_ENABLE_DTC = true
+      })
+
       it('should display an error when navigating directly to results page', () => {
         cy.visit(route('results', lang))
         cy.get('[data-cy=missed-questions]')
@@ -24,6 +29,7 @@ describe('Paths and Benefits', () => {
     describe('Language: ' + lang, () => {
 
       beforeEach(() => {
+        process.env.FF_ENABLE_DTC = true
         cy.visit('/' + lang)
         cy.reportA11y()
         cy.get('[data-cy=start]').click()

--- a/cypress/integration/results.spec.js
+++ b/cypress/integration/results.spec.js
@@ -7,6 +7,7 @@ describe('Result Page Only tests', () => {
 
       beforeEach(() => {
         process.env.FF_ENABLE_DTC = true
+        process.env.COOKIE_SECRET = 'result'
       })
 
       it('should display an error when navigating directly to results page', () => {
@@ -30,6 +31,7 @@ describe('Paths and Benefits', () => {
 
       beforeEach(() => {
         process.env.FF_ENABLE_DTC = true
+        process.env.COOKIE_SECRET = 'paths'
         cy.visit('/' + lang)
         cy.reportA11y()
         cy.get('[data-cy=start]').click()

--- a/middleware/featureFlags.js
+++ b/middleware/featureFlags.js
@@ -1,0 +1,12 @@
+const featureFlags = (req, res, next) => {
+
+  req.locals.featureFlags = {
+    enableDtc : process.env.FF_ENABLE_DTC || false,
+  }
+
+  next()
+}
+
+module.exports = {
+  featureFlags,
+}

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -6,6 +6,7 @@ const errorHandler = require('./errorHandler')
 const csrfToken = require('./csrfToken')
 const assetPath = require('./assetPath')
 const assetVersion = require('./assetVersion')
+const featureFlags = require('./featureFlags')
 
 module.exports = {
   ...domainRedirector,
@@ -16,4 +17,5 @@ module.exports = {
   ...csrfToken,
   ...assetPath,
   ...assetVersion,
+  ...featureFlags,
 }

--- a/routes/question-oas/question-oas.controller.js
+++ b/routes/question-oas/question-oas.controller.js
@@ -10,5 +10,16 @@ module.exports = (app, route) => {
         title: res.__("oas.title"),
       }))
     })
-    .post(route.applySchema(Schema), route.doRedirect())
+    .post(route.applySchema(Schema), (req, res) => {
+
+      let path
+      if (req.locals.featureFlags.enableDtc){
+        path = res.locals.routePath('question-dtc')
+      } else {
+        path = res.locals.routePath('prepare')
+      }
+
+
+      return res.redirect(path)
+    })
 }

--- a/routes/results/getBenefits.spec.js
+++ b/routes/results/getBenefits.spec.js
@@ -1,4 +1,5 @@
-const { getBenefits, getProvincialBenefits } = require('./getBenefits')
+const  getBenefits  = (data) => require('./getBenefits').getBenefits(data, {enableDtc: true})
+const { getProvincialBenefits } = require('./getBenefits')
 
 describe('Test the getBenefits calculator', () => {
 

--- a/routes/results/results.controller.js
+++ b/routes/results/results.controller.js
@@ -28,9 +28,9 @@ module.exports = (app, route) => {
       const data = getData(req, res);
 
       // get All Benefits (except provinces and GST)
-      const benefitsFullList = _.pull(getAllBenefits(), 'gst_credit');
+      const benefitsFullList = _.pull(getAllBenefits(req.locals.featureFlags), 'gst_credit');
 
-      const benefits = getBenefits(data);
+      const benefits = getBenefits(data, req.locals.featureFlags);
       let unavailableBenefits = benefitsFullList.filter((benefit) => !benefits.includes(benefit))
 
       // We need to remove DTC if the user matches one of the variants

--- a/terraform/azure/app-service-docker.tf
+++ b/terraform/azure/app-service-docker.tf
@@ -26,6 +26,7 @@ resource "azurerm_app_service" "app_service" {
     "DOCKER_REGISTRY_SERVER_USERNAME" = azurerm_container_registry.container_registry.admin_username
     #"DOCKER_REGISTRY_SERVER_PASSWORD" = azurerm_container_registry.container_registry.admin_password
     "DOCKER_REGISTRY_SERVER_PASSWORD" = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.docker_password.name}/${azurerm_key_vault_secret.docker_password.version})"
+    "FF_ENABLE_DTC"                   = "false"
     "SLOT_NAME"                       = "default"
 
   }
@@ -63,6 +64,7 @@ resource "azurerm_app_service_slot" "staging" {
     "DOCKER_REGISTRY_SERVER_USERNAME" = azurerm_container_registry.container_registry.admin_username
     #"DOCKER_REGISTRY_SERVER_PASSWORD" = azurerm_container_registry.container_registry.admin_password
     "DOCKER_REGISTRY_SERVER_PASSWORD" = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.docker_password.name}/${azurerm_key_vault_secret.docker_password.version})"
+    "FF_ENABLE_DTC"                   = "false"
     "SLOT_NAME"                       = "staging"
   }
 
@@ -100,6 +102,7 @@ resource "azurerm_app_service_slot" "dev" {
     "DOCKER_REGISTRY_SERVER_USERNAME" = azurerm_container_registry.container_registry.admin_username
     #"DOCKER_REGISTRY_SERVER_PASSWORD" = azurerm_container_registry.container_registry.admin_password
     "DOCKER_REGISTRY_SERVER_PASSWORD" = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.docker_password.name}/${azurerm_key_vault_secret.docker_password.version})"
+    "FF_ENABLE_DTC"                   = "false"
     "SLOT_NAME"                       = "dev"
   }
 


### PR DESCRIPTION
# Description

Add a feature flag to allow us to enable DTC through an environment variable.

## Test Instructions

1. Pull code down locally and run
1. Run code with no FF_ENABLE_DTC environment variable set, it should default to false.
1. Verify that after the OAS question no DTC question is shown.
1. On the results page verify that no DTC is shown in the not applicable list
1. Set FF_ENABLE_DTC to true 
1. verify that the DTC question is displayed after OAS
1. Verify that DTC Shows as expected on results page.

## Help Requested

- The list of not-applicable benefits should be verified
