### PR TITLE
Removed duplicate back button on results page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this product will be documented in this file.
 
+## 2020-06-17
+
+### Removed
+* A duplicate back button has been removed from the results page
+
 ## 2020-06-16
 
 ### Removed

--- a/app.js
+++ b/app.js
@@ -38,6 +38,7 @@ const {
   assetVersion,
   featureFlags,
   headerConfig,
+  startOver,
 } = require('./middleware')
 
 // check to see if we have a custom configRoutes function
@@ -111,6 +112,7 @@ app.locals.hasData = hasData
 app.use(assetPath(app))
 app.use(assetVersion(app))
 
+app.use(startOver)
 
 app.use((req, res, next) => {
   app.locals.pageUrl = req.protocol + '://' + req.get('host') + req.originalUrl

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -8,6 +8,7 @@ const assetPath = require('./assetPath')
 const assetVersion = require('./assetVersion')
 const featureFlags = require('./featureFlags')
 const headerConfig = require('./headerConfig')
+const startOver = require('./startOver')
 
 module.exports = {
   ...domainRedirector,
@@ -20,4 +21,5 @@ module.exports = {
   ...assetVersion,
   ...featureFlags,
   ...headerConfig,
+  ...startOver,
 }

--- a/middleware/session.js
+++ b/middleware/session.js
@@ -20,7 +20,6 @@ const session = (req, res, next) => {
     }
   }
 
-
   next()
 }
 

--- a/middleware/startOver.js
+++ b/middleware/startOver.js
@@ -1,0 +1,14 @@
+const startOver = (req, res, next) => {
+  // show or hide the start over button on the results page
+  if (req.path === '/en/results' || req.path === '/fr/resultats') {
+    res.locals.showStartOver = true
+  } else {
+    res.locals.showStartOver = false
+  }
+
+  next()
+}
+
+module.exports = {
+  startOver,
+}

--- a/middleware/startOver.spec.js
+++ b/middleware/startOver.spec.js
@@ -1,0 +1,53 @@
+const { startOver } = require('./startOver')
+
+test('The start over button on the english results page is visible', async () => {
+  var req = {
+    path: '/en/results',
+  }
+  var res = {
+    locals: {},
+  }
+
+  startOver(req, res, () => {})
+
+  expect(res.locals.showStartOver).toBe(true)
+})
+
+test('The start over button on the french results page is visible', async () => {
+  var req = {
+    path: '/fr/resultats',
+  }
+  var res = {
+    locals: {},
+  }
+
+  startOver(req, res, () => {})
+
+  expect(res.locals.showStartOver).toBe(true)
+})
+
+test('The start over button on any other english page is not visible', async () => {
+  var req = {
+    path: '/en/start',
+  }
+  var res = {
+    locals: {},
+  }
+
+  startOver(req, res, () => {})
+
+  expect(res.locals.showStartOver).toBe(false)
+})
+
+test('The start over button on any other french page is not visible', async () => {
+  var req = {
+    path: '/fr/debut',
+  }
+  var res = {
+    locals: {},
+  }
+
+  startOver(req, res, () => {})
+
+  expect(res.locals.showStartOver).toBe(false)
+})

--- a/routes/results/results.njk
+++ b/routes/results/results.njk
@@ -7,12 +7,11 @@
 
 {% block content %}
 
-    <div class="flex flex-row">
-        {% include "_includes/back-link.njk" %}
+    {# <div class="flex flex-row">
         <div class="inline -mt-12">
             <a class="ml-6 py-3 button-link transparent" href="/clear"><img src="{{ asset('/img/times-circle.svg') }}" class="h-6 w-6" alt="" /><span>{{ __('start_over') }}</span></a>
         </div>
-    </div>
+    </div> #}
 
     <h1>{{ __('results.header') }}</h1>
 

--- a/views/_includes/back-link.njk
+++ b/views/_includes/back-link.njk
@@ -1,5 +1,9 @@
-<div class="mb-10 md:mb-6 -mt-6">
-  <a href="/back" class="">
+{# <a href="/back" class="ml-6 py-3 button-link transparent inline">
+  <img src="{{ asset('/img/arrow-circle-left.svg') }}" alt="" class="w-6 h-6 inline-block md:-mt-1" /><span class="inline-block ml-3 underline">{{__('button.back')}}</span>
+</a> #}
+
+{# <div class="-mt-12"> #}
+  <a href="/back" class="button-link py-3 transparent">
     <img src="{{ asset('/img/arrow-circle-left.svg') }}" alt="" class="w-6 h-6 inline-block md:-mt-1" /><span class="inline-block ml-3 underline">{{__('button.back')}}</span>
   </a>
-</div>
+{# <div> #}

--- a/views/_includes/back-link.njk
+++ b/views/_includes/back-link.njk
@@ -1,9 +1,3 @@
-{# <a href="/back" class="ml-6 py-3 button-link transparent inline">
+ <a href="/back" class="button-link py-3 transparent">
   <img src="{{ asset('/img/arrow-circle-left.svg') }}" alt="" class="w-6 h-6 inline-block md:-mt-1" /><span class="inline-block ml-3 underline">{{__('button.back')}}</span>
-</a> #}
-
-{# <div class="-mt-12"> #}
-  <a href="/back" class="button-link py-3 transparent">
-    <img src="{{ asset('/img/arrow-circle-left.svg') }}" alt="" class="w-6 h-6 inline-block md:-mt-1" /><span class="inline-block ml-3 underline">{{__('button.back')}}</span>
-  </a>
-{# <div> #}
+</a>

--- a/views/base.njk
+++ b/views/base.njk
@@ -38,9 +38,14 @@
                 {% include "_includes/fip.njk" %}
             </header>
             <main id="content">
-                {% if not hideBackButton %}
-                  {% include "_includes/back-link.njk" %}
-                {% endif %}
+                <div class="flex flex-row -mt-6 md:mb-6">
+                    {% if not hideBackButton %}
+                        {% include "_includes/back-link.njk" %}
+                    {% endif %}
+                    {% if showStartOver %}
+                        <a class="ml-6 py-3 button-link transparent" href="/clear"><img src="{{ asset('/img/times-circle.svg') }}" class="h-6 w-6" alt="" /><span>{{ __('start_over') }}</span></a>
+                    {% endif %}
+                </div>
                 {% if errors %}
                     {% include "_includes/errorList.njk" %}
                 {% endif %}

--- a/views/base.njk
+++ b/views/base.njk
@@ -38,12 +38,12 @@
                 {% include "_includes/fip.njk" %}
             </header>
             <main id="content">
-                <div class="flex flex-row -mt-6 md:mb-6">
+                <div class="-mt-6">
                     {% if not hideBackButton %}
                         {% include "_includes/back-link.njk" %}
                     {% endif %}
                     {% if showStartOver %}
-                        <a class="ml-6 py-3 button-link transparent" href="/clear"><img src="{{ asset('/img/times-circle.svg') }}" class="h-6 w-6" alt="" /><span>{{ __('start_over') }}</span></a>
+                        <a class="py-3 button-link transparent" href="/clear"><img src="{{ asset('/img/times-circle.svg') }}" class="h-6 w-6" alt="" /><span>{{ __('start_over') }}</span></a>
                     {% endif %}
                 </div>
                 {% if errors %}


### PR DESCRIPTION
# Description

Removed a duplicate back button on the results page. Aligned the back button with the start over button on the results page as well. Because of the change, some logic was added to hide the start over button while not on the results page.

Not the results page
![image](https://user-images.githubusercontent.com/34345435/84942578-0f437300-b0b1-11ea-9f97-b28cc442f5cd.png)

The results page
![image](https://user-images.githubusercontent.com/34345435/84942626-25e9ca00-b0b1-11ea-8fbb-dfe53bf744e4.png)

## Test Instructions

Step through the questionnaire and notice the start over button is at the bottom, as it should be. Once at the results page, the start over button should be at the top of the page, beside the back button.

## Checklist
- [x] Update CHANGELOG.md
- [x] Unit tests have been added/updated
- [ ] e2e tests have been added/updated