### PR TITLE
Change feedback form to use Adobe Analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,6 @@ NOTIFY_ENDPOINT=
 NOTIFY_API_KEY=
 FEEDBACK_EMAIL_TO=
 
-# Required for Airtable integration
-AIRTABLE_API_KEY=
-AIRTABLE_BASE_ID=
 
 # Required for CDN integration
 CDN_PREFIX=

--- a/.snyk
+++ b/.snyk
@@ -4,8 +4,6 @@ ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-LODASH-567746:
-    - airtable > lodash:
-        patched: '2020-05-01T03:09:36.436Z'
     - express-validator > lodash:
         patched: '2020-05-01T03:09:36.436Z'
     - tailwindcss > lodash:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this product will be documented in this file.
 
+## 2020-06-23
+
+### Changed
+* Feedback form now saves data to Adobe Analytics
+
 ## 2020-06-17
 
 ### Removed

--- a/assets/js/feedback.js
+++ b/assets/js/feedback.js
@@ -54,3 +54,9 @@ if (form) {
   // intercept the form submit
   form.addEventListener('submit', submitFeedback)
 }
+
+var feedbackContainer = document.getElementsByClassName('feedback-container')[0];
+
+if (feedbackContainer) {
+  feedbackContainer.className = feedbackContainer.className.replace(/\bno-js\b/g, "");
+}

--- a/assets/scss/_forms.scss
+++ b/assets/scss/_forms.scss
@@ -267,3 +267,9 @@ form {
     margin-bottom: $space-xxs;
   }
 }
+
+.feedback-container {
+  &.no-js {
+    display: none;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2894,70 +2894,6 @@
         }
       }
     },
-    "airtable": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/airtable/-/airtable-0.8.1.tgz",
-      "integrity": "sha512-Cxw55ta1olDwDERz++HFJOBX6LONtg+d7+wOcYguqI4PR4P5RHmgjTbY8tPKgLHb8U3FVOyAbpb7NpLRSnLGgg==",
-      "requires": {
-        "es6-promise": "4.2.8",
-        "lodash": "4.17.15",
-        "request": "2.88.0",
-        "xhr": "2.3.3"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-        },
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
-      }
-    },
     "ajv": {
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
@@ -5575,11 +5511,6 @@
         }
       }
     },
-    "dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -7216,22 +7147,6 @@
         "is-glob": "^4.0.1"
       }
     },
-    "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
-      },
-      "dependencies": {
-        "process": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-        }
-      }
-    },
     "global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -8315,11 +8230,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-    },
-    "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -11389,14 +11299,6 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "min-indent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
@@ -12573,11 +12475,6 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
-    },
-    "parse-headers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
     },
     "parse-json": {
       "version": "4.0.0",
@@ -17770,17 +17667,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
-    },
-    "xhr": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.3.3.tgz",
-      "integrity": "sha1-rWuBDgkXznK17HBPXUHxUDuOdSQ=",
-      "requires": {
-        "global": "~4.3.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
-      }
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@csstools/postcss-sass": "^4.0.0",
     "accessible-autocomplete": "^2.0.2",
-    "applicationinsights": "^1.7.5",
+    "applicationinsights": "^1.7.6",
     "clean-webpack-plugin": "^3.0.0",
     "compression": "^1.7.4",
     "cookie-parser": "~1.4.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "@csstools/postcss-sass": "^4.0.0",
     "accessible-autocomplete": "^2.0.2",
-    "airtable": "^0.8.1",
     "applicationinsights": "^1.7.5",
     "clean-webpack-plugin": "^3.0.0",
     "compression": "^1.7.4",

--- a/routes/feedback/feedback.controller.js
+++ b/routes/feedback/feedback.controller.js
@@ -36,7 +36,6 @@ module.exports = (app, route) => {
     console.log(JSON.stringify({ feedback: feedback }))
 
     sendNotification(feedback)
-    saveToAirtable(feedback)
 
     return res.redirect(res.locals.routePath('feedback-thanks'))
   })
@@ -69,28 +68,4 @@ const sendNotification = (feedback) => {
     )
     .then((response) => console.log('Sent by email'))
     .catch((err) => console.error(err))
-}
-
-const saveToAirtable = (feedback) => {
-  if (!(process.env.AIRTABLE_API_KEY && process.env.AIRTABLE_BASE_ID)) {
-    return
-  }
-  const base = require('airtable').base(process.env.AIRTABLE_BASE_ID)
-
-  base('Feedback').create(
-    [
-      {
-        fields: feedback,
-      },
-    ],
-    function (err, records) {
-      if (err) {
-        console.error(err)
-        return
-      }
-      records.forEach(function (record) {
-        console.log('Saved to Airtable: ' + record.getId())
-      })
-    },
-  )
 }

--- a/terraform/azure/app-service-docker.tf
+++ b/terraform/azure/app-service-docker.tf
@@ -18,8 +18,6 @@ resource "azurerm_app_service" "app_service" {
     "ADOBE_ENV"                       = "production"
     "APPINSIGHTS_INSTRUMENTATIONKEY"  = azurerm_application_insights.covid-benefit.instrumentation_key
     "APP_SERVICE"                     = "true"
-    "AIRTABLE_API_KEY"                = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.airtable_api_key.name}/${azurerm_key_vault_secret.airtable_api_key.version})"
-    "AIRTABLE_BASE_ID"                = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.airtable_base_id.name}/${azurerm_key_vault_secret.airtable_base_id.version})"
     "CDN_PREFIX"                      = "//cv19-benefits-cdn.azureedge.net"
     "COOKIE_SECRET"                   = "lhnhtvsnaavmlxjrqct"
     "DOCKER_REGISTRY_SERVER_URL"      = "https://${azurerm_container_registry.container_registry.login_server}"

--- a/terraform/azure/keyvault.tf
+++ b/terraform/azure/keyvault.tf
@@ -70,17 +70,3 @@ resource "azurerm_key_vault_secret" "docker_password" {
   key_vault_id = azurerm_key_vault.key_vault.id
   depends_on   = [azurerm_key_vault_access_policy.tf_identity]
 }
-
-resource "azurerm_key_vault_secret" "airtable_api_key" {
-  name         = "AirtableApiKey"
-  value        = var.airtable_api_key
-  key_vault_id = azurerm_key_vault.key_vault.id
-  depends_on   = [azurerm_key_vault_access_policy.tf_identity]
-}
-
-resource "azurerm_key_vault_secret" "airtable_base_id" {
-  name         = "AirtableBaseId"
-  value        = var.airtable_base_id
-  key_vault_id = azurerm_key_vault.key_vault.id
-  depends_on   = [azurerm_key_vault_access_policy.tf_identity]
-}

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -14,12 +14,3 @@ variable "docker_image" {
 variable "docker_image_tag" {
   description = "(Optional) Specify the tag to be deployed"
 }
-
-
-variable "airtable_api_key" {
-  description = "(Required) API Key for airtable shoudld be kept secret and in an a terraform variables file that isn't in git"
-}
-
-variable "airtable_base_id" {
-  description = "(Required) API Key for airtable shoudld be kept secret and in an a terraform variables file that isn't in git"
-}

--- a/views/_includes/back-link.njk
+++ b/views/_includes/back-link.njk
@@ -1,3 +1,3 @@
- <a href="/back" class="button-link py-3 transparent">
+ <a href="/back" class="button-link py-3 transparent no-js">
   <img src="{{ asset('/img/arrow-circle-left.svg') }}" alt="" class="w-6 h-6 inline-block md:-mt-1" /><span class="inline-block ml-3 underline">{{__('button.back')}}</span>
 </a>

--- a/views/_includes/back-link.njk
+++ b/views/_includes/back-link.njk
@@ -1,3 +1,3 @@
- <a href="/back" class="button-link py-3 transparent no-js">
+ <a href="/back" class="button-link py-3 transparent">
   <img src="{{ asset('/img/arrow-circle-left.svg') }}" alt="" class="w-6 h-6 inline-block md:-mt-1" /><span class="inline-block ml-3 underline">{{__('button.back')}}</span>
 </a>

--- a/views/_includes/feedback.njk
+++ b/views/_includes/feedback.njk
@@ -1,4 +1,4 @@
-<details class="w-full sm:w-1/2 md:w-3/5 lg:w-2/5 mt-20">
+<details class="w-full sm:w-1/2 md:w-3/5 lg:w-2/5 mt-20 no-js feedback-container">
     <summary class="px-4 py-2 bg-gray-300 rounded text-center">{{ __('feedback.button') }}</summary>
     <div class="px-8 py-6 rounded border border-gray-300 bg-gray-200">
 
@@ -6,7 +6,7 @@
         {{ banner('red', '<p><strong>' + __('feedback.error') + '</strong></p>')}}
       </div>
 
-      <form action="/{{ getLocale() }}/feedback" method="post" class="" id="feedback-form">
+      <form action="/{{ getLocale() }}/feedback" method="post" class="" id="feedback-form" data-gc-analytics-formname='ESDC|EDSC:Covid19 Benefits RAP' data-gc-analytics-collect='[{"value":"input[type=checkbox]","emptyField": "Any"}]'>
         <input type="hidden" name="_csrf" id="feedback-csrf" value="{{ csrfToken }}">
 
         <fieldset class="fieldset">


### PR DESCRIPTION
# Description

Airtable has been dropped in favour of Adobe Analytics. All code references to Airtable are gone. Since Adobe Analytics requires Javascript, the feedback form will be hidden if Javascript is disabled.

## Test Instructions

If Javascript is enabled:
Inspect the feedback form element and note that `data-gc-analytics-formname='ESDC|EDSC:Covid19 Benefits RAP' data-gc-analytics-collect='[{"value":"input[type=checkbox]","emptyField": "Any"}]'` is in the form element.

If Javascript is disabled:
Notice that the feedback form does not appear on any of the pages.
