### PR TITLE
Adding instructions to return to the applicatoin from the feedback submission pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this product will be documented in this file.
 
+## 2020-06-26
+
+### Added
+* Instructions on how to return to the application from the feedback submission (error and thanks) pages. These pages are only available when Javascript is disabled
+* The back button on the feedback submission pages now returns you to the page where you submitted the feedback
+
 ## 2020-06-17
 
 ### Removed

--- a/locales/en.json
+++ b/locales/en.json
@@ -63,6 +63,7 @@
   "feedback.submit": "Submit",
   "feedback.tell_us_more": "Can you tell us more?",
   "feedback.thanks": "Thank you for your feedback.",
+  "feedback.go_back": "To return to the previous page, click on the Back button.",
   "footer.contact": "https://www.canada.ca/en/contact.html",
   "footer.contact.desc": "Contact information",
   "footer.privacy": "https://digital.canada.ca/legal/privacy/",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -63,6 +63,7 @@
   "feedback.submit": "Soumettre",
   "feedback.tell_us_more": "Pouvez-vous décrire le problème?",
   "feedback.thanks": "Merci de nous avoir aidés à améliorer le service!",
+  "feedback.go_back": "Pour retourner à la page précédente, cliquez sur le bouton Retour.",
   "footer.contact": "https://www.canada.ca/fr/contact.html",
   "footer.contact.desc": "Coordonnées",
   "footer.privacy": "https://numerique.canada.ca/transparence/confidentialite/",

--- a/routes/feedback-error/feedback-error.njk
+++ b/routes/feedback-error/feedback-error.njk
@@ -8,6 +8,9 @@
         <p>
         {{ banner('red', '<p><strong>' + __('feedback.error') + '</strong></p>') }}
         </p>
+        <p>
+            {{ __('feedback.go_back') }}
+        </p>
     </div>
 
 {% endblock %}

--- a/routes/feedback-thanks/feedback-thanks.njk
+++ b/routes/feedback-thanks/feedback-thanks.njk
@@ -8,6 +8,9 @@
         <p>
             {{ __('feedback-thanks.text') }}
         </p>
+        <p>
+            {{ __('feedback.go_back') }}
+        </p>
     </div>
 
 {% endblock %}

--- a/routes/feedback/feedback.controller.js
+++ b/routes/feedback/feedback.controller.js
@@ -5,12 +5,20 @@ module.exports = (app, route) => {
 
     const problems = req.body.problems || []
 
-    if (problems.length === 0 && req.body.details === '') {
+    const url = new URL(req.headers.referer)
+
+    if (req.session.history === undefined){
+      req.session.history = []
+    }
+    req.session.history.push(url.pathname)
+
+    console.log(`problem length: ${problems.length}`)
+    console.log(`req body: ${req.body.details}`)
+    if (problems.length === 0 && (req.body.details === undefined || req.body.details === '')) {
       console.log('redirecting to feedback-error')
       return res.redirect(res.locals.routePath('feedback-error'))
     }
 
-    const url = new URL(req.headers.referer)
     const feedback = {
       incorrect_info: +problems.includes('incorrect_info'),
       confusing_info: +problems.includes('confusing_info'),

--- a/routes/feedback/feedback.controller.js
+++ b/routes/feedback/feedback.controller.js
@@ -12,8 +12,6 @@ module.exports = (app, route) => {
     }
     req.session.history.push(url.pathname)
 
-    console.log(`problem length: ${problems.length}`)
-    console.log(`req body: ${req.body.details}`)
     if (problems.length === 0 && (req.body.details === undefined || req.body.details === '')) {
       console.log('redirecting to feedback-error')
       return res.redirect(res.locals.routePath('feedback-error'))

--- a/routes/feedback/feedback.controller.spec.js
+++ b/routes/feedback/feedback.controller.spec.js
@@ -30,10 +30,14 @@ test('Redirect to thanks with just problems', async () => {
 })
 
 test('Redirect to feedback error', async () => {
-  const response = await request(app).post(feedbackRoute.path.en).send({
-    problems: undefined,
-    details: '',
-  })
+  const response = await request(app)
+    .post(feedbackRoute.path.en)
+    .set('referer', 'http://foo.bar')
+    .send({
+      problems: undefined,
+      details: '',
+    })
+  
   expect(response.statusCode).toBe(302)
   expect(response.headers.location).toBe(feedbackError.path.en)
 })


### PR DESCRIPTION
# Note to reviewers
Since the change to Adobe Analytics, the feedback form now requires Javascript to be enabled in order to submit feedback. Because Javascript is required, the feedback form is now hidden when Javascript is disabled. **The pages under review will not be reachable in the applications current state.** The purpose of this PR is if the feedback changes again and these pages become necessary once more.

# Description

A sentence was added to the feedback-thanks and feedback-error pages, informing the user to click the back button to return to the application. These pages are only available when Javascript is disabled.

The thanks page with instructions:
![image](https://user-images.githubusercontent.com/34345435/85882962-30414d80-b7ae-11ea-9eda-69af8911b68c.png)

The error page with instructions:
![image](https://user-images.githubusercontent.com/34345435/85882987-3afbe280-b7ae-11ea-8939-bcb6f09865ee.png)


## Test Instructions

1. Make sure Javascript is turned off in your browser of choice
2a. Submit feedback from any page
3a. The feedback thanks page contains information on how to return to the application

2b. Submit the feedback form from any page without selecting any of the checkboxes
3b. The feedback error page contains information on how to return to the application
